### PR TITLE
fix: Screaming snake case

### DIFF
--- a/src/casing.test.ts
+++ b/src/casing.test.ts
@@ -1,50 +1,50 @@
 import type * as Subject from './casing'
 import * as subject from './casing'
 
-const weirdString = ' someWeird-cased$*String1986Foo Bar W_FOR_WAMBO' as const
+const weirdString = ' someWeird-cased$*String1986Foo Bar W_FOR_WUMBO' as const
 type WeirdString = typeof weirdString
 
 namespace TypeTransforms {
   type test = Expect<
     Equal<
       Subject.DelimiterCase<WeirdString, '%'>,
-      'some%Weird%cased%$*%String%1986%Foo%Bar%W%FOR%WAMBO'
+      'some%Weird%cased%$*%String%1986%Foo%Bar%W%FOR%WUMBO'
     >
   >
   type test1 = Expect<
     Equal<
       Subject.CamelCase<WeirdString>,
-      'someWeirdCased$*String1986FooBarWForWambo'
+      'someWeirdCased$*String1986FooBarWForWumbo'
     >
   >
   type test2 = Expect<
     Equal<
       Subject.PascalCase<WeirdString>,
-      'SomeWeirdCased$*String1986FooBarWForWambo'
+      'SomeWeirdCased$*String1986FooBarWForWumbo'
     >
   >
   type test3 = Expect<
     Equal<
       Subject.KebabCase<WeirdString>,
-      'some-weird-cased-$*-string-1986-foo-bar-w-for-wambo'
+      'some-weird-cased-$*-string-1986-foo-bar-w-for-wumbo'
     >
   >
   type test4 = Expect<
     Equal<
       Subject.SnakeCase<WeirdString>,
-      'some_weird_cased_$*_string_1986_foo_bar_w_for_wambo'
+      'some_weird_cased_$*_string_1986_foo_bar_w_for_wumbo'
     >
   >
   type test5 = Expect<
     Equal<
       Subject.ConstantCase<WeirdString>,
-      'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR_W_FOR_WAMBO'
+      'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR_W_FOR_WUMBO'
     >
   >
   type test6 = Expect<
     Equal<
       Subject.TitleCase<WeirdString>,
-      'Some Weird Cased $* String 1986 Foo Bar W For Wambo'
+      'Some Weird Cased $* String 1986 Foo Bar W For Wumbo'
     >
   >
 }
@@ -67,14 +67,14 @@ describe('capitalize', () => {
 
 describe('casing functions', () => {
   test('toUpperCase', () => {
-    const expected = ' SOMEWEIRD-CASED$*STRING1986FOO BAR W_FOR_WAMBO' as const
+    const expected = ' SOMEWEIRD-CASED$*STRING1986FOO BAR W_FOR_WUMBO' as const
     const result = subject.toUpperCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toLowerCase', () => {
-    const expected = ' someweird-cased$*string1986foo bar w_for_wambo' as const
+    const expected = ' someweird-cased$*string1986foo bar w_for_wumbo' as const
     const result = subject.toLowerCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
@@ -82,21 +82,21 @@ describe('casing functions', () => {
 
   test('toDelimiterCase', () => {
     const expected =
-      'some@Weird@cased@$*@String@1986@Foo@Bar@W@FOR@WAMBO' as const
+      'some@Weird@cased@$*@String@1986@Foo@Bar@W@FOR@WUMBO' as const
     const result = subject.toDelimiterCase(weirdString, '@')
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toCamelCase', () => {
-    const expected = 'someWeirdCased$*String1986FooBarWForWambo' as const
+    const expected = 'someWeirdCased$*String1986FooBarWForWumbo' as const
     const result = subject.toCamelCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toPascalCase', () => {
-    const expected = 'SomeWeirdCased$*String1986FooBarWForWambo' as const
+    const expected = 'SomeWeirdCased$*String1986FooBarWForWumbo' as const
     const result = subject.toPascalCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
@@ -104,7 +104,7 @@ describe('casing functions', () => {
 
   test('toKebabCase', () => {
     const expected =
-      'some-weird-cased-$*-string-1986-foo-bar-w-for-wambo' as const
+      'some-weird-cased-$*-string-1986-foo-bar-w-for-wumbo' as const
     const result = subject.toKebabCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
@@ -112,7 +112,7 @@ describe('casing functions', () => {
 
   test('toSnakeCase', () => {
     const expected =
-      'some_weird_cased_$*_string_1986_foo_bar_w_for_wambo' as const
+      'some_weird_cased_$*_string_1986_foo_bar_w_for_wumbo' as const
     const result = subject.toSnakeCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
@@ -120,9 +120,9 @@ describe('casing functions', () => {
 
   test('toConstantCase', () => {
     const expected =
-      'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR_W_FOR_WAMBO' as const
+      'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR_W_FOR_WUMBO' as const
     const result = subject.toConstantCase(
-      ' someWeird-cased$*String1986Foo Bar W_FOR_WAMBO',
+      ' someWeird-cased$*String1986Foo Bar W_FOR_WUMBO',
     )
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
@@ -130,7 +130,7 @@ describe('casing functions', () => {
 
   test('toTitleCase', () => {
     const expected =
-      'Some Weird Cased $* String 1986 Foo Bar W For Wambo' as const
+      'Some Weird Cased $* String 1986 Foo Bar W For Wumbo' as const
     const result = subject.toTitleCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>

--- a/src/casing.test.ts
+++ b/src/casing.test.ts
@@ -88,6 +88,14 @@ describe('casing functions', () => {
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
+  test('toCamelCase (screaming_snake_case)', () => {
+    const value = 'EXAMPLE_VALUE'
+    const result = subject.toCamelCase(value)
+    const expected = 'exampleValue' as const
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
   test('toPascalCase', () => {
     const expected = 'SomeWeirdCased$*String1986FooBar' as const
     const result = subject.toPascalCase(weirdString)

--- a/src/casing.test.ts
+++ b/src/casing.test.ts
@@ -1,44 +1,50 @@
 import type * as Subject from './casing'
 import * as subject from './casing'
 
-const weirdString = ' someWeird-cased$*String1986Foo Bar ' as const
+const weirdString = ' someWeird-cased$*String1986Foo Bar W_FOR_WAMBO' as const
 type WeirdString = typeof weirdString
 
 namespace TypeTransforms {
   type test = Expect<
     Equal<
       Subject.DelimiterCase<WeirdString, '%'>,
-      'some%Weird%cased%$*%String%1986%Foo%Bar'
+      'some%Weird%cased%$*%String%1986%Foo%Bar%W%FOR%WAMBO'
     >
   >
   type test1 = Expect<
-    Equal<Subject.CamelCase<WeirdString>, 'someWeirdCased$*String1986FooBar'>
+    Equal<
+      Subject.CamelCase<WeirdString>,
+      'someWeirdCased$*String1986FooBarWForWambo'
+    >
   >
   type test2 = Expect<
-    Equal<Subject.PascalCase<WeirdString>, 'SomeWeirdCased$*String1986FooBar'>
+    Equal<
+      Subject.PascalCase<WeirdString>,
+      'SomeWeirdCased$*String1986FooBarWForWambo'
+    >
   >
   type test3 = Expect<
     Equal<
       Subject.KebabCase<WeirdString>,
-      'some-weird-cased-$*-string-1986-foo-bar'
+      'some-weird-cased-$*-string-1986-foo-bar-w-for-wambo'
     >
   >
   type test4 = Expect<
     Equal<
       Subject.SnakeCase<WeirdString>,
-      'some_weird_cased_$*_string_1986_foo_bar'
+      'some_weird_cased_$*_string_1986_foo_bar_w_for_wambo'
     >
   >
   type test5 = Expect<
     Equal<
       Subject.ConstantCase<WeirdString>,
-      'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR'
+      'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR_W_FOR_WAMBO'
     >
   >
   type test6 = Expect<
     Equal<
       Subject.TitleCase<WeirdString>,
-      'Some Weird Cased $* String 1986 Foo Bar'
+      'Some Weird Cased $* String 1986 Foo Bar W For Wambo'
     >
   >
 }
@@ -61,73 +67,70 @@ describe('capitalize', () => {
 
 describe('casing functions', () => {
   test('toUpperCase', () => {
-    const expected = ' SOMEWEIRD-CASED$*STRING1986FOO BAR ' as const
+    const expected = ' SOMEWEIRD-CASED$*STRING1986FOO BAR W_FOR_WAMBO' as const
     const result = subject.toUpperCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toLowerCase', () => {
-    const expected = ' someweird-cased$*string1986foo bar ' as const
+    const expected = ' someweird-cased$*string1986foo bar w_for_wambo' as const
     const result = subject.toLowerCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toDelimiterCase', () => {
-    const expected = 'some@Weird@cased@$*@String@1986@Foo@Bar' as const
+    const expected =
+      'some@Weird@cased@$*@String@1986@Foo@Bar@W@FOR@WAMBO' as const
     const result = subject.toDelimiterCase(weirdString, '@')
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toCamelCase', () => {
-    const expected = 'someWeirdCased$*String1986FooBar' as const
+    const expected = 'someWeirdCased$*String1986FooBarWForWambo' as const
     const result = subject.toCamelCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
-  test('toCamelCase (screaming_snake_case)', () => {
-    const value = 'EXAMPLE_VALUE'
-    const result = subject.toCamelCase(value)
-    const expected = 'exampleValue' as const
-    expect(result).toEqual(expected)
-    type test = Expect<Equal<typeof result, typeof expected>>
-  })
-
   test('toPascalCase', () => {
-    const expected = 'SomeWeirdCased$*String1986FooBar' as const
+    const expected = 'SomeWeirdCased$*String1986FooBarWForWambo' as const
     const result = subject.toPascalCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toKebabCase', () => {
-    const expected = 'some-weird-cased-$*-string-1986-foo-bar' as const
+    const expected =
+      'some-weird-cased-$*-string-1986-foo-bar-w-for-wambo' as const
     const result = subject.toKebabCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toSnakeCase', () => {
-    const expected = 'some_weird_cased_$*_string_1986_foo_bar' as const
+    const expected =
+      'some_weird_cased_$*_string_1986_foo_bar_w_for_wambo' as const
     const result = subject.toSnakeCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toConstantCase', () => {
-    const expected = 'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR' as const
+    const expected =
+      'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR_W_FOR_WAMBO' as const
     const result = subject.toConstantCase(
-      ' someWeird-cased$*String1986Foo Bar ',
+      ' someWeird-cased$*String1986Foo Bar W_FOR_WAMBO',
     )
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
   test('toTitleCase', () => {
-    const expected = 'Some Weird Cased $* String 1986 Foo Bar' as const
+    const expected =
+      'Some Weird Cased $* String 1986 Foo Bar W For Wambo' as const
     const result = subject.toTitleCase(weirdString)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>

--- a/src/casing.ts
+++ b/src/casing.ts
@@ -1,4 +1,4 @@
-import { CapitalizeAll } from './internals'
+import { CapitalizeAll, LowercaseAll } from './internals'
 import { Join, join } from './primitives'
 import { Is, Words, words } from './utils'
 
@@ -55,7 +55,12 @@ function toDelimiterCase<T extends string, D extends string>(
  * Transforms a string to camelCase.
  */
 type CamelCase<T extends string> = Words<T> extends [infer first, ...infer rest]
-  ? Join<[Lowercase<Is<first, string>>, ...CapitalizeAll<Is<rest, string[]>>]>
+  ? Join<
+      [
+        Lowercase<Is<first, string>>,
+        ...CapitalizeAll<LowercaseAll<Is<rest, string[]>>>,
+      ]
+    >
   : T
 /**
  * A strongly typed version of `toCamelCase` that works in both runtime and type level.
@@ -64,7 +69,7 @@ type CamelCase<T extends string> = Words<T> extends [infer first, ...infer rest]
  * @example toCamelCase('hello world') // 'helloWorld'
  */
 function toCamelCase<T extends string>(str: T) {
-  const result = words(str).map(capitalize).join('')
+  const result = words(str).map(toLowerCase).map(capitalize).join('')
   return (result.slice(0, 1).toLowerCase() + result.slice(1)) as CamelCase<T>
 }
 

--- a/src/casing.ts
+++ b/src/casing.ts
@@ -1,4 +1,4 @@
-import { CapitalizeAll, LowercaseAll } from './internals'
+import { PascalCaseAll } from './internals'
 import { Join, join } from './primitives'
 import { Is, Words, words } from './utils'
 
@@ -55,12 +55,7 @@ function toDelimiterCase<T extends string, D extends string>(
  * Transforms a string to camelCase.
  */
 type CamelCase<T extends string> = Words<T> extends [infer first, ...infer rest]
-  ? Join<
-      [
-        Lowercase<Is<first, string>>,
-        ...CapitalizeAll<LowercaseAll<Is<rest, string[]>>>,
-      ]
-    >
+  ? Join<[Lowercase<Is<first, string>>, ...PascalCaseAll<Is<rest, string[]>>]>
   : T
 /**
  * A strongly typed version of `toCamelCase` that works in both runtime and type level.
@@ -76,7 +71,7 @@ function toCamelCase<T extends string>(str: T) {
 /**
  * Transforms a string to PascalCase.
  */
-type PascalCase<T extends string> = Capitalize<CamelCase<T>>
+type PascalCase<T extends string> = Join<PascalCaseAll<Is<Words<T>, string[]>>>
 /**
  * A strongly typed version of `toPascalCase` that works in both runtime and type level.
  * @param str the string to convert to pascal case.

--- a/src/casing.ts
+++ b/src/casing.ts
@@ -69,9 +69,8 @@ type CamelCase<T extends string> = Words<T> extends [infer first, ...infer rest]
  * @example toCamelCase('hello world') // 'helloWorld'
  */
 function toCamelCase<T extends string>(str: T) {
-  return words(str)
-    .map((v, i) => (i > 0 ? capitalize(toLowerCase(v)) : toLowerCase(v)))
-    .join('') as CamelCase<T>
+  const res = toPascalCase(str)
+  return (res.slice(0, 1).toLowerCase() + res.slice(1)) as CamelCase<T>
 }
 
 /**
@@ -85,7 +84,9 @@ type PascalCase<T extends string> = Capitalize<CamelCase<T>>
  * @example toPascalCase('hello world') // 'HelloWorld'
  */
 function toPascalCase<T extends string>(str: T): PascalCase<T> {
-  return capitalize(toCamelCase(str))
+  return words(str)
+    .map((v) => capitalize(toLowerCase(v)))
+    .join('') as PascalCase<T>
 }
 
 /**

--- a/src/casing.ts
+++ b/src/casing.ts
@@ -54,9 +54,10 @@ function toDelimiterCase<T extends string, D extends string>(
 /**
  * Transforms a string to camelCase.
  */
-type CamelCase<T extends string> = Words<T> extends [infer first, ...infer rest]
-  ? Join<[Lowercase<Is<first, string>>, ...PascalCaseAll<Is<rest, string[]>>]>
-  : T
+type CamelCase<T extends string> =
+  PascalCase<T> extends `${infer first}${infer rest}`
+    ? `${Lowercase<first>}${rest}`
+    : T
 /**
  * A strongly typed version of `toCamelCase` that works in both runtime and type level.
  * @param str the string to convert to camel case.

--- a/src/casing.ts
+++ b/src/casing.ts
@@ -69,8 +69,9 @@ type CamelCase<T extends string> = Words<T> extends [infer first, ...infer rest]
  * @example toCamelCase('hello world') // 'helloWorld'
  */
 function toCamelCase<T extends string>(str: T) {
-  const result = words(str).map(toLowerCase).map(capitalize).join('')
-  return (result.slice(0, 1).toLowerCase() + result.slice(1)) as CamelCase<T>
+  return words(str)
+    .map((v, i) => (i > 0 ? capitalize(toLowerCase(v)) : toLowerCase(v)))
+    .join('') as CamelCase<T>
 }
 
 /**

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -47,18 +47,14 @@ type DropSuffix<
 > = sentence extends `${infer rest}${suffix}` ? rest : sentence
 
 /**
- * Capitalizes all the words in a tuple of strings
+ * PascalCases all the words in a tuple of strings
  */
-type CapitalizeAll<T extends string[]> = T extends [infer First, ...infer Rest]
-  ? [Capitalize<Is<First, string>>, ...CapitalizeAll<Is<Rest, string[]>>]
+type PascalCaseAll<T extends string[]> = T extends [infer First, ...infer Rest]
+  ? [
+      Capitalize<Lowercase<Is<First, string>>>,
+      ...PascalCaseAll<Is<Rest, string[]>>,
+    ]
   : T
 
-/**
- * Lowercases all the words in a tuple of strings
- */
-type LowercaseAll<T extends string[]> = T extends [infer First, ...infer Rest]
-  ? [Lowercase<Is<First, string>>, ...LowercaseAll<Is<Rest, string[]>>]
-  : T
-
-export type { CapitalizeAll, LowercaseAll, Drop, DropSuffix }
+export type { PascalCaseAll, Drop, DropSuffix }
 export { typeOf }

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -53,5 +53,12 @@ type CapitalizeAll<T extends string[]> = T extends [infer First, ...infer Rest]
   ? [Capitalize<Is<First, string>>, ...CapitalizeAll<Is<Rest, string[]>>]
   : T
 
-export type { CapitalizeAll, Drop, DropSuffix }
+/**
+ * Lowercases all the words in a tuple of strings
+ */
+type LowercaseAll<T extends string[]> = T extends [infer First, ...infer Rest]
+  ? [Lowercase<Is<First, string>>, ...LowercaseAll<Is<Rest, string[]>>]
+  : T
+
+export type { CapitalizeAll, LowercaseAll, Drop, DropSuffix }
 export { typeOf }

--- a/src/key-casing.test.ts
+++ b/src/key-casing.test.ts
@@ -106,7 +106,7 @@ describe('key transformation', () => {
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
-  test('deepCamelKeys on object using screaming snake case', () => {
+  test('deepCamelKeys (SCREAMING_SNAKE_CASE)', () => {
     const obj = {
       NODE_ENV: 'development',
     }

--- a/src/key-casing.test.ts
+++ b/src/key-casing.test.ts
@@ -106,6 +106,18 @@ describe('key transformation', () => {
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
+  test('deepCamelKeys on object using screaming snake case', () => {
+    const obj = {
+      NODE_ENV: 'development',
+    }
+    const expected = {
+      nodeEnv: 'development',
+    }
+    const result = subject.deepCamelKeys(obj)
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
   test('deepSnakeKeys', () => {
     const expected = {
       some: { deep_nested: { value: true } },


### PR DESCRIPTION
The `toCamelCase` and `deepCamelKeys` functions have unexpected behavior when the argument involves SCREAMING_SNAKE_CASE.

Related to: https://github.com/gustavoguichard/string-ts/issues/6