### PR TITLE
Add `split` method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,76 @@
-export * from './primitives'
-export * from './utils'
-export * from './casing'
-export * from './key-casing'
+// PRIMITIVES
+export type {
+  Join,
+  Replace,
+  ReplaceAll,
+  Split,
+  TrimStart,
+  TrimEnd,
+  Trim,
+} from './primitives'
+export {
+  join,
+  replace,
+  replaceAll,
+  split,
+  trim,
+  trimStart,
+  trimEnd,
+} from './primitives'
+
+// UTILS
+export type {
+  Digit,
+  Is,
+  IsDigit,
+  IsLetter,
+  IsLower,
+  IsSeparator,
+  IsSpecial,
+  IsUpper,
+  Separator,
+  Words,
+} from './utils'
+export { words } from './utils'
+
+// CASING
+export type {
+  CamelCase,
+  ConstantCase,
+  DelimiterCase,
+  KebabCase,
+  PascalCase,
+  SnakeCase,
+  TitleCase,
+} from './casing'
+export {
+  capitalize,
+  toCamelCase,
+  toConstantCase,
+  toDelimiterCase,
+  toKebabCase,
+  toLowerCase,
+  toPascalCase,
+  toSnakeCase,
+  toTitleCase,
+  toUpperCase,
+} from './casing'
+
+// KEY CASING
+export type {
+  DeepCamelKeys,
+  DeepConstantKeys,
+  DeepDelimiterKeys,
+  DeepKebabKeys,
+  DeepPascalKeys,
+  DeepSnakeKeys,
+} from './key-casing'
+export {
+  deepCamelKeys,
+  deepConstantKeys,
+  deepDelimiterKeys,
+  deepKebabKeys,
+  deepPascalKeys,
+  deepSnakeKeys,
+  deepTransformKeys,
+} from './key-casing'

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -20,6 +20,9 @@ namespace TypeTests {
   type test6 = Expect<
     Equal<Subject.Trim<' some nice string '>, 'some nice string'>
   >
+  type test7 = Expect<
+    Equal<Subject.Split<'some nice string', ' '>, ['some', 'nice', 'string']>
+  >
 }
 
 describe('primitives', () => {
@@ -54,6 +57,15 @@ describe('primitives', () => {
       const result = subject.replaceAll(data, ' ')
       expect(result).toEqual('somenicestring')
       type test = Expect<Equal<typeof result, 'somenicestring'>>
+    })
+  })
+
+  test('split', () => {
+    test('should split a string by a delimiter into an array of substrings', () => {
+      const data = 'some nice string'
+      const result = subject.split(data, ' ')
+      expect(result).toEqual(['some', 'nice', 'string'])
+      type test = Expect<Equal<typeof result, ['some', 'nice', 'string']>>
     })
   })
 

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -99,6 +99,28 @@ function replaceAll<T extends string, S extends string, R extends string = ''>(
 }
 
 /**
+ * Splits a string into an array of substrings.
+ * T: The string to split.
+ * delimiter: The delimiter.
+ */
+type Split<
+  T,
+  delimiter extends string,
+> = T extends `${infer first}${delimiter}${infer rest}`
+  ? [first, ...Split<rest, delimiter>]
+  : [T]
+/**
+ * A strongly typed version of `String.prototype.split`.
+ * @param str the string to split.
+ * @param delimiter the delimiter.
+ * @returns the splitted string in both type level and runtime.
+ * @example split('hello world', ' ') // ['hello', 'world']
+ */
+function split<T extends string, D extends string = ''>(str: T, delimiter?: D) {
+  return str.split(delimiter ?? ('' as const)) as Split<T, D>
+}
+
+/**
  * Trims all whitespaces at the start of a string.
  * T: The string to trim.
  */
@@ -146,5 +168,5 @@ function trim<T extends string>(str: T) {
   return str.trim() as Trim<T>
 }
 
-export type { Join, Replace, ReplaceAll, TrimStart, TrimEnd, Trim }
-export { join, replace, replaceAll, trim, trimStart, trimEnd }
+export type { Join, Replace, ReplaceAll, Split, TrimStart, TrimEnd, Trim }
+export { join, replace, replaceAll, split, trim, trimStart, trimEnd }


### PR DESCRIPTION
Adds a strongly-typed `split` method as an alternative to the native one.