### PR TITLE
fix: union types with camelCase

### DIFF
--- a/src/casing.test.ts
+++ b/src/casing.test.ts
@@ -47,6 +47,12 @@ namespace TypeTransforms {
       'Some Weird Cased $* String 1986 Foo Bar W For Wumbo'
     >
   >
+  type test7 = Expect<
+    Equal<
+      Subject.CamelCase<'hello world' | 'Other Test' | 'whoops'>,
+      'helloWorld' | 'otherTest' | 'whoops'
+    >
+  >
 }
 
 describe('capitalize', () => {

--- a/src/casing.ts
+++ b/src/casing.ts
@@ -54,10 +54,12 @@ function toDelimiterCase<T extends string, D extends string>(
 /**
  * Transforms a string to camelCase.
  */
-type CamelCase<T extends string> =
-  PascalCase<T> extends `${infer first}${infer rest}`
+type CamelCase<T extends string> = T extends unknown
+  ? PascalCase<T> extends `${infer first}${infer rest}`
     ? `${Lowercase<first>}${rest}`
     : T
+  : never
+
 /**
  * A strongly typed version of `toCamelCase` that works in both runtime and type level.
  * @param str the string to convert to camel case.


### PR DESCRIPTION
Relates to https://github.com/gustavoguichard/string-ts/issues/9

## Description

Extending `unknown` prevents the camel-case mapping from being distributive over the union type, and instead it transforms all elements in the same way.