### PR TITLE
feat: add not deep keys casing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm install string-ts
   - [toSnakeCase](#tosnakecase)
   - [toConstantCase](#toconstantcase)
   - [toTitleCase](#totitlecase)
-- [Strongly-typed deep transformation of objects](#strongly-typed-transformation-of-objects)
+- [Strongly-typed shallow transformation of objects](#strongly-typed-shallow-transformation-of-objects)
   - [DelimiterKeys](#delimiterkeys)
   - [CamelKeys](#camelkeys)
   - [PascalKeys](#pascalkeys)
@@ -278,10 +278,10 @@ const result = toTitleCase(str);
 //    ^ 'Hello World'
 ```
 
-## Strongly-typed transformation of objects
+## Strongly-typed shallow transformation of objects
 
 ### delimiterKeys
-This function recursively converts the keys of an object to a new case with a custom delimiter at both runtime and type levels.
+This function shallowly converts the keys of an object to a new case with a custom delimiter at both runtime and type levels.
 
 ```ts
 import { delimiterKeys } from 'string-ts';
@@ -296,7 +296,7 @@ const result = delimiterKeys(data, '.');
 ```
 
 ### camelKeys
-This function recursively converts the keys of an object to `camelCase` at both runtime and type levels.
+This function shallowly converts the keys of an object to `camelCase` at both runtime and type levels.
 
 ```ts
 import { camelKeys } from 'string-ts';
@@ -311,7 +311,7 @@ const result = camelKeys(data);
 ```
 
 ### pascalKeys
-This function recursively converts the keys of an object to `PascalCase` at both runtime and type levels.
+This function shallowly converts the keys of an object to `PascalCase` at both runtime and type levels.
 
 ```ts
 import { pascalKeys } from 'string-ts';
@@ -326,7 +326,7 @@ const result = pascalKeys(data);
 ```
 
 ### kebabKeys
-This function recursively converts the keys of an object to `kebab-case` at both runtime and type levels.
+This function shallowly converts the keys of an object to `kebab-case` at both runtime and type levels.
 
 ```ts
 import { kebabKeys } from 'string-ts';
@@ -341,7 +341,7 @@ const result = kebabKeys(data);
 ```
 
 ### snakeKeys
-This function recursively converts the keys of an object to `snake_case` at both runtime and type levels.
+This function shallowly converts the keys of an object to `snake_case` at both runtime and type levels.
 
 ```ts
 import { snakeKeys } from 'string-ts';
@@ -356,7 +356,7 @@ const result = snakeKeys(data);
 ```
 
 ### constantKeys
-This function recursively converts the keys of an object to `CONSTANT_CASE` at both runtime and type levels.
+This function shallowly converts the keys of an object to `CONSTANT_CASE` at both runtime and type levels.
 
 ```ts
 import { constantKeys } from 'string-ts';

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ npm install string-ts
   - [toSnakeCase](#tosnakecase)
   - [toConstantCase](#toconstantcase)
   - [toTitleCase](#totitlecase)
+- [Strongly-typed deep transformation of objects](#strongly-typed-transformation-of-objects)
+  - [DelimiterKeys](#delimiterkeys)
+  - [CamelKeys](#camelkeys)
+  - [PascalKeys](#pascalkeys)
+  - [KebabKeys](#kebabkeys)
+  - [SnakeKeys](#snakekeys)
+  - [ConstantKeys](#constantkeys)
 - [Strongly-typed deep transformation of objects](#strongly-typed-deep-transformation-of-objects)
   - [deepDelimiterKeys](#deepdelimiterkeys)
   - [deepCamelKeys](#deepcamelkeys)
@@ -269,6 +276,98 @@ import { toTitleCase } from 'string-ts';
 const str = 'helloWorld';
 const result = toTitleCase(str);
 //    ^ 'Hello World'
+```
+
+## Strongly-typed transformation of objects
+
+### delimiterKeys
+This function recursively converts the keys of an object to a new case with a custom delimiter at both runtime and type levels.
+
+```ts
+import { delimiterKeys } from 'string-ts';
+
+const data = {
+  'hello-world': {
+    'foo-bar': 'baz',
+  },
+} as const;
+const result = delimiterKeys(data, '.');
+//    ^ { 'hello.world': { 'foo-bar': 'baz' } }
+```
+
+### camelKeys
+This function recursively converts the keys of an object to `camelCase` at both runtime and type levels.
+
+```ts
+import { camelKeys } from 'string-ts';
+
+const data = {
+  'hello-world': {
+    'foo-bar': 'baz',
+  },
+} as const;
+const result = camelKeys(data);
+//    ^ { helloWorld: { 'foo-bar': 'baz' } }
+```
+
+### pascalKeys
+This function recursively converts the keys of an object to `PascalCase` at both runtime and type levels.
+
+```ts
+import { pascalKeys } from 'string-ts';
+
+const data = {
+  'hello-world': {
+    'foo-bar': 'baz',
+  },
+} as const;
+const result = pascalKeys(data);
+//    ^ { HelloWorld: { FooBar: 'baz' } }
+```
+
+### kebabKeys
+This function recursively converts the keys of an object to `kebab-case` at both runtime and type levels.
+
+```ts
+import { kebabKeys } from 'string-ts';
+
+const data = {
+  'helloWorld': {
+    'fooBar': 'baz',
+  },
+} as const;
+const result = kebabKeys(data);
+//    ^ { 'hello-world': { fooBar: 'baz' } }
+```
+
+### snakeKeys
+This function recursively converts the keys of an object to `snake_case` at both runtime and type levels.
+
+```ts
+import { snakeKeys } from 'string-ts';
+
+const data = {
+  'helloWorld': {
+    'fooBar': 'baz',
+  },
+} as const;
+const result = snakeKeys(data);
+//    ^ { 'hello_world': { 'fooBar': 'baz' } }
+```
+
+### constantKeys
+This function recursively converts the keys of an object to `CONSTANT_CASE` at both runtime and type levels.
+
+```ts
+import { constantKeys } from 'string-ts';
+
+const data = {
+  'helloWorld': {
+    'fooBar': 'baz',
+  },
+} as const;
+const result = constantKeys(data);
+//    ^ { 'HELLO_WORLD': { 'fooBar': 'baz' } }
 ```
 
 ## Strongly-typed deep transformation of objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,14 +58,22 @@ export {
 
 // KEY CASING
 export type {
+  CamelKeys,
+  ConstantKeys,
   DeepCamelKeys,
   DeepConstantKeys,
   DeepDelimiterKeys,
   DeepKebabKeys,
   DeepPascalKeys,
   DeepSnakeKeys,
+  DelimiterKeys,
+  KebabKeys,
+  PascalKeys,
+  SnakeKeys,
 } from './key-casing'
 export {
+  camelKeys,
+  constantKeys,
   deepCamelKeys,
   deepConstantKeys,
   deepDelimiterKeys,
@@ -73,4 +81,8 @@ export {
   deepPascalKeys,
   deepSnakeKeys,
   deepTransformKeys,
+  delimiterKeys,
+  kebabKeys,
+  pascalKeys,
+  snakeKeys,
 } from './key-casing'

--- a/src/key-casing.test.ts
+++ b/src/key-casing.test.ts
@@ -2,7 +2,7 @@ import type * as Subject from './key-casing'
 import * as subject from './key-casing'
 
 namespace TypeTransforms {
-  type test = Expect<
+  type deepTest = Expect<
     Equal<
       Subject.DeepDelimiterKeys<
         {
@@ -14,7 +14,19 @@ namespace TypeTransforms {
       { some: { 'deep@nested': { value: true } }; 'other@value': true }
     >
   >
-  type test1 = Expect<
+  type test = Expect<
+    Equal<
+      Subject.DelimiterKeys<
+        {
+          'some-value': { 'nested-value': true }
+          'other-value': true
+        },
+        '@'
+      >,
+      { 'some@value': { 'nested-value': true }; 'other@value': true }
+    >
+  >
+  type deepTest1 = Expect<
     Equal<
       Subject.DeepCamelKeys<{
         some: { 'deep-nested': { value: true } }
@@ -23,7 +35,16 @@ namespace TypeTransforms {
       { some: { deepNested: { value: true } }; otherValue: true }
     >
   >
-  type test2 = Expect<
+  type test1 = Expect<
+    Equal<
+      Subject.CamelKeys<{
+        'some-value': { 'deep-nested': true }
+        'other-value': true
+      }>,
+      { someValue: { 'deep-nested': true }; otherValue: true }
+    >
+  >
+  type deepTest2 = Expect<
     Equal<
       Subject.DeepSnakeKeys<{
         some: { 'deep-nested': { value: true } }
@@ -32,7 +53,16 @@ namespace TypeTransforms {
       { some: { deep_nested: { value: true } }; other_value: true }
     >
   >
-  type test3 = Expect<
+  type test2 = Expect<
+    Equal<
+      Subject.SnakeKeys<{
+        'some-value': { 'deep-nested': true }
+        'other-value': true
+      }>,
+      { some_value: { 'deep-nested': true }; other_value: true }
+    >
+  >
+  type deepTest3 = Expect<
     Equal<
       Subject.DeepKebabKeys<{
         some: { deepNested: { value: true } }
@@ -41,7 +71,16 @@ namespace TypeTransforms {
       { some: { 'deep-nested': { value: true } }; 'other-value': true }
     >
   >
-  type test4 = Expect<
+  type test3 = Expect<
+    Equal<
+      Subject.KebabKeys<{
+        someValue: { deepNested: true }
+        otherValue: true
+      }>,
+      { 'some-value': { deepNested: true }; 'other-value': true }
+    >
+  >
+  type deepTest4 = Expect<
     Equal<
       Subject.DeepPascalKeys<{
         some: { 'deep-nested': { value: true } }
@@ -50,13 +89,31 @@ namespace TypeTransforms {
       { Some: { DeepNested: { Value: true } }; OtherValue: true }
     >
   >
-  type test5 = Expect<
+  type test4 = Expect<
+    Equal<
+      Subject.PascalKeys<{
+        someValue: { deepNested: true }
+        otherValue: true
+      }>,
+      { SomeValue: { deepNested: true }; OtherValue: true }
+    >
+  >
+  type deepTest5 = Expect<
     Equal<
       Subject.DeepConstantKeys<{
         some: { 'deep-nested': { value: true } }
         'other-value': true
       }>,
       { SOME: { DEEP_NESTED: { VALUE: true } }; OTHER_VALUE: true }
+    >
+  >
+  type test5 = Expect<
+    Equal<
+      Subject.ConstantKeys<{
+        someValue: { deepNested: true }
+        otherValue: true
+      }>,
+      { SOME_VALUE: { deepNested: true }; OTHER_VALUE: true }
     >
   >
 }
@@ -68,6 +125,21 @@ describe('key transformation', () => {
       'OTHER-VALUE': true,
     }
     const result = subject.deepTransformKeys(
+      {
+        some: { 'deep-nested': { value: true } },
+        'other-value': true,
+      },
+      (key) => key.toUpperCase(),
+    )
+    expect(result).toEqual(expected)
+  })
+
+  test('transformKeys', () => {
+    const expected = {
+      SOME: { 'deep-nested': { value: true } },
+      'OTHER-VALUE': true,
+    }
+    const result = subject.transformKeys(
       {
         some: { 'deep-nested': { value: true } },
         'other-value': true,
@@ -93,12 +165,41 @@ describe('key transformation', () => {
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
+  test('delimiterKeys', () => {
+    const expected = {
+      some: { 'deep-nested': { value: true } },
+      'other@value': true,
+    }
+    const result = subject.delimiterKeys(
+      {
+        some: { 'deep-nested': { value: true } },
+        'other-value': true,
+      },
+      '@',
+    )
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
   test('deepCamelKeys', () => {
     const expected = {
       some: { deepNested: { value: true } },
       otherValue: true,
     }
     const result = subject.deepCamelKeys({
+      some: { 'deep-nested': { value: true } },
+      'other-value': true,
+    })
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('camelKeys', () => {
+    const expected = {
+      some: { 'deep-nested': { value: true } },
+      otherValue: true,
+    }
+    const result = subject.camelKeys({
       some: { 'deep-nested': { value: true } },
       'other-value': true,
     })
@@ -118,12 +219,37 @@ describe('key transformation', () => {
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
+  test('camelKeys (SCREAMING_SNAKE_CASE)', () => {
+    const obj = {
+      NODE_ENV: 'development',
+    }
+    const expected = {
+      nodeEnv: 'development',
+    }
+    const result = subject.camelKeys(obj)
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
   test('deepSnakeKeys', () => {
     const expected = {
       some: { deep_nested: { value: true } },
       other_value: true,
     }
     const result = subject.deepSnakeKeys({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('snakeKeys', () => {
+    const expected = {
+      some: { deepNested: { value: true } },
+      other_value: true,
+    }
+    const result = subject.snakeKeys({
       some: { deepNested: { value: true } },
       otherValue: true,
     })
@@ -144,6 +270,19 @@ describe('key transformation', () => {
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
+  test('kebabKeys', () => {
+    const expected = {
+      some: { deepNested: { value: true } },
+      'other-value': true,
+    }
+    const result = subject.kebabKeys({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
   test('deepPascalKeys', () => {
     const expected = {
       Some: { DeepNested: { Value: true } },
@@ -157,12 +296,38 @@ describe('key transformation', () => {
     type test = Expect<Equal<typeof result, typeof expected>>
   })
 
+  test('pascalKeys', () => {
+    const expected = {
+      Some: { deepNested: { value: true } },
+      OtherValue: true,
+    }
+    const result = subject.pascalKeys({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
   test('deepConstantKeys', () => {
     const expected = {
       SOME: { DEEP_NESTED: { VALUE: true } },
       OTHER_VALUE: true,
     }
     const result = subject.deepConstantKeys({
+      some: { deepNested: { value: true } },
+      otherValue: true,
+    })
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('constantKeys', () => {
+    const expected = {
+      SOME: { deepNested: { value: true } },
+      OTHER_VALUE: true,
+    }
+    const result = subject.constantKeys({
       some: { deepNested: { value: true } },
       otherValue: true,
     })

--- a/src/key-casing.test.ts
+++ b/src/key-casing.test.ts
@@ -334,4 +334,18 @@ describe('key transformation', () => {
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>
   })
+
+  test('deepTransformKeys should handle null properly', () => {
+    const expected = null
+    const result = subject.deepConstantKeys(null)
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('transformKeys should handle null properly', () => {
+    const expected = null
+    const result = subject.constantKeys(null)
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
 })

--- a/src/key-casing.ts
+++ b/src/key-casing.ts
@@ -38,6 +38,25 @@ function deepTransformKeys<T>(obj: T, transform: (s: string) => string): T {
 }
 
 /**
+ * This function is used to transform the keys of an object.
+ * It will only be transformed at runtime, so it's not type safe.
+ * @param obj the object to transform.
+ * @param transform the function to transform the keys from string to string.
+ * @returns the transformed object.
+ * @example deepTransformKeys({ 'foo-bar': { 'fizz-buzz': true } }, toCamelCase)
+ * // { fooBar: { 'fizz-buzz': true } }
+ */
+function transformKeys<T>(obj: T, transform: (s: string) => string): T {
+  if (typeOf(obj) !== 'object') return obj
+
+  const res = {} as T
+  for (const key in obj) {
+    res[transform(key) as keyof T] = obj[key]
+  }
+  return res
+}
+
+/**
  * Transforms the keys of an Record to camelCase.
  * T: the type of the Record to transform.
  */
@@ -49,6 +68,13 @@ type DeepCamelKeys<T> = T extends [any, ...any]
       [K in keyof T as CamelCase<Is<K, string>>]: DeepCamelKeys<T[K]>
     }
 /**
+ * Transforms the keys of an Record to camelCase.
+ * T: the type of the Record to transform.
+ */
+type CamelKeys<T> = T extends []
+  ? T
+  : { [K in keyof T as CamelCase<Is<K, string>>]: T[K] }
+/**
  * A strongly typed function that recursively transforms the keys of an object to camelCase. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
@@ -57,9 +83,18 @@ type DeepCamelKeys<T> = T extends [any, ...any]
 function deepCamelKeys<T>(obj: T): DeepCamelKeys<T> {
   return deepTransformKeys(obj, toCamelCase) as never
 }
+/**
+ * A strongly typed function that transforms the keys of an object to camelCase. The transformation is done both at runtime and type level.
+ * @param obj the object to transform.
+ * @returns the transformed object.
+ * @example camelKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { fooBar: { 'fizz-buz': true } }
+ */
+function camelKeys<T>(obj: T): CamelKeys<T> {
+  return transformKeys(obj, toCamelCase) as never
+}
 
 /**
- * Transforms the keys of an Record to PascalCase.
+ * Recursively transforms the keys of an Record to PascalCase.
  * T: the type of the Record to transform.
  */
 type DeepPascalKeys<T> = T extends [any, ...any]
@@ -70,6 +105,13 @@ type DeepPascalKeys<T> = T extends [any, ...any]
       [K in keyof T as PascalCase<Is<K, string>>]: DeepPascalKeys<T[K]>
     }
 /**
+ * Transforms the keys of an Record to PascalCase.
+ * T: the type of the Record to transform.
+ */
+type PascalKeys<T> = T extends []
+  ? T
+  : { [K in keyof T as PascalCase<Is<K, string>>]: T[K] }
+/**
  * A strongly typed function that recursively transforms the keys of an object to pascal case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
@@ -78,9 +120,18 @@ type DeepPascalKeys<T> = T extends [any, ...any]
 function deepPascalKeys<T>(obj: T): DeepPascalKeys<T> {
   return deepTransformKeys(obj, toPascalCase) as never
 }
+/**
+ * A strongly typed function that transforms the keys of an object to pascal case. The transformation is done both at runtime and type level.
+ * @param obj the object to transform.
+ * @returns the transformed object.
+ * @example pascalKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { FooBar: { 'fizz-buzz': true } }
+ */
+function pascalKeys<T>(obj: T): PascalKeys<T> {
+  return transformKeys(obj, toPascalCase) as never
+}
 
 /**
- * Transforms the keys of an Record to kebab-case.
+ * Recursively transforms the keys of an Record to kebab-case.
  * T: the type of the Record to transform.
  */
 type DeepKebabKeys<T> = T extends [any, ...any]
@@ -91,6 +142,15 @@ type DeepKebabKeys<T> = T extends [any, ...any]
       [K in keyof T as KebabCase<Is<K, string>>]: DeepKebabKeys<T[K]>
     }
 /**
+ * Transforms the keys of an Record to kebab-case.
+ * T: the type of the Record to transform.
+ */
+type KebabKeys<T> = T extends []
+  ? T
+  : {
+      [K in keyof T as KebabCase<Is<K, string>>]: T[K]
+    }
+/**
  * A strongly typed function that recursively transforms the keys of an object to kebab-case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
@@ -99,9 +159,18 @@ type DeepKebabKeys<T> = T extends [any, ...any]
 function deepKebabKeys<T>(obj: T): DeepKebabKeys<T> {
   return deepTransformKeys(obj, toKebabCase) as never
 }
+/**
+ * A strongly typed function that transforms the keys of an object to kebab-case. The transformation is done both at runtime and type level.
+ * @param obj the object to transform.
+ * @returns the transformed object.
+ * @example kebabKeys({ fooBar: { fizzBuzz: true } }) // { 'foo-bar': { fizzBuzz: true } }
+ */
+function kebabKeys<T>(obj: T): KebabKeys<T> {
+  return transformKeys(obj, toKebabCase) as never
+}
 
 /**
- * Transforms the keys of an Record to snake_case.
+ * Recursively transforms the keys of an Record to snake_case.
  * T: the type of the Record to transform.
  */
 type DeepSnakeKeys<T> = T extends [any, ...any]
@@ -112,6 +181,14 @@ type DeepSnakeKeys<T> = T extends [any, ...any]
       [K in keyof T as SnakeCase<Is<K, string>>]: DeepSnakeKeys<T[K]>
     }
 /**
+ * Transforms the keys of an Record to snake_case.
+ * T: the type of the Record to transform.
+ */
+type SnakeKeys<T> = T extends []
+  ? T
+  : { [K in keyof T as SnakeCase<Is<K, string>>]: T[K] }
+
+/**
  * A strongly typed function that recursively transforms the keys of an object to snake_case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
@@ -120,9 +197,18 @@ type DeepSnakeKeys<T> = T extends [any, ...any]
 function deepSnakeKeys<T>(obj: T): DeepSnakeKeys<T> {
   return deepTransformKeys(obj, toSnakeCase) as never
 }
+/**
+ * A strongly typed function that transforms the keys of an object to snake_case. The transformation is done both at runtime and type level.
+ * @param obj the object to transform.
+ * @returns the transformed object.
+ * @example snakeKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { 'foo_bar': { 'fizz-buzz': true } }
+ */
+function snakeKeys<T>(obj: T): SnakeKeys<T> {
+  return transformKeys(obj, toSnakeCase) as never
+}
 
 /**
- * Transforms the keys of an Record to CONSTANT_CASE.
+ * Recursively transforms the keys of an Record to CONSTANT_CASE.
  * T: the type of the Record to transform.
  */
 type DeepConstantKeys<T> = T extends [any, ...any]
@@ -133,6 +219,13 @@ type DeepConstantKeys<T> = T extends [any, ...any]
       [K in keyof T as ConstantCase<Is<K, string>>]: DeepConstantKeys<T[K]>
     }
 /**
+ * Transforms the keys of an Record to CONSTANT_CASE.
+ * T: the type of the Record to transform.
+ */
+type ConstantKeys<T> = T extends []
+  ? T
+  : { [K in keyof T as ConstantCase<Is<K, string>>]: T[K] }
+/**
  * A strongly typed function that recursively transforms the keys of an object to CONSTANT_CASE. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
@@ -141,9 +234,18 @@ type DeepConstantKeys<T> = T extends [any, ...any]
 function deepConstantKeys<T>(obj: T): DeepConstantKeys<T> {
   return deepTransformKeys(obj, toConstantCase) as never
 }
+/**
+ * A strongly typed function that transforms the keys of an object to CONSTANT_CASE. The transformation is done both at runtime and type level.
+ * @param obj the object to transform.
+ * @returns the transformed object.
+ * @example constantKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { FOO_BAR: { 'fizz-buzz': true } }
+ */
+function constantKeys<T>(obj: T): ConstantKeys<T> {
+  return transformKeys(obj, toConstantCase) as never
+}
 
 /**
- * Transforms the keys of an Record to a custom delimiter case.
+ * Recursively transforms the keys of an Record to a custom delimiter case.
  * T: the type of the Record to transform.
  * D: the delimiter to use.
  */
@@ -157,6 +259,14 @@ type DeepDelimiterKeys<T, D extends string> = T extends [any, ...any]
         D
       >
     }
+/**
+ * Transforms the keys of an Record to a custom delimiter case.
+ * T: the type of the Record to transform.
+ * D: the delimiter to use.
+ */
+type DelimiterKeys<T, D extends string> = T extends []
+  ? T
+  : { [K in keyof T as DelimiterCase<Is<K, string>, D>]: T[K] }
 /**
  * A strongly typed function that recursively transforms the keys of an object to a custom delimiter case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
@@ -172,16 +282,37 @@ function deepDelimiterKeys<T, D extends string>(
     toDelimiterCase(str, delimiter),
   ) as never
 }
+/**
+ * A strongly typed function that recursively the keys of an object to a custom delimiter case. The transformation is done both at runtime and type level.
+ * @param obj the object to transform.
+ * @param delimiter the delimiter to use.
+ * @returns the transformed object.
+ * @example deepDelimiterKeys({ 'foo-bar': { 'fizz-buzz': true } }, '.') // { 'foo.bar': { 'fizz.buzz': true } }
+ */
+function delimiterKeys<T, D extends string>(
+  obj: T,
+  delimiter: D,
+): DelimiterKeys<T, D> {
+  return transformKeys(obj, (str) => toDelimiterCase(str, delimiter)) as never
+}
 
 export type {
+  CamelKeys,
+  ConstantKeys,
   DeepCamelKeys,
   DeepConstantKeys,
   DeepDelimiterKeys,
   DeepKebabKeys,
   DeepPascalKeys,
   DeepSnakeKeys,
+  DelimiterKeys,
+  KebabKeys,
+  PascalKeys,
+  SnakeKeys,
 }
 export {
+  camelKeys,
+  constantKeys,
   deepCamelKeys,
   deepConstantKeys,
   deepDelimiterKeys,
@@ -189,4 +320,9 @@ export {
   deepPascalKeys,
   deepSnakeKeys,
   deepTransformKeys,
+  delimiterKeys,
+  kebabKeys,
+  pascalKeys,
+  snakeKeys,
+  transformKeys,
 }

--- a/src/key-casing.ts
+++ b/src/key-casing.ts
@@ -38,12 +38,12 @@ function deepTransformKeys<T>(obj: T, transform: (s: string) => string): T {
 }
 
 /**
- * This function is used to transform the keys of an object.
+ * This function is used to shallowly transform the keys of an object.
  * It will only be transformed at runtime, so it's not type safe.
  * @param obj the object to transform.
  * @param transform the function to transform the keys from string to string.
  * @returns the transformed object.
- * @example deepTransformKeys({ 'foo-bar': { 'fizz-buzz': true } }, toCamelCase)
+ * @example transformKeys({ 'foo-bar': { 'fizz-buzz': true } }, toCamelCase)
  * // { fooBar: { 'fizz-buzz': true } }
  */
 function transformKeys<T>(obj: T, transform: (s: string) => string): T {
@@ -57,7 +57,7 @@ function transformKeys<T>(obj: T, transform: (s: string) => string): T {
 }
 
 /**
- * Transforms the keys of an Record to camelCase.
+ * Recursively transforms the keys of an Record to camelCase.
  * T: the type of the Record to transform.
  */
 type DeepCamelKeys<T> = T extends [any, ...any]
@@ -68,7 +68,7 @@ type DeepCamelKeys<T> = T extends [any, ...any]
       [K in keyof T as CamelCase<Is<K, string>>]: DeepCamelKeys<T[K]>
     }
 /**
- * Transforms the keys of an Record to camelCase.
+ * Shallowly transforms the keys of an Record to camelCase.
  * T: the type of the Record to transform.
  */
 type CamelKeys<T> = T extends []
@@ -84,7 +84,7 @@ function deepCamelKeys<T>(obj: T): DeepCamelKeys<T> {
   return deepTransformKeys(obj, toCamelCase) as never
 }
 /**
- * A strongly typed function that transforms the keys of an object to camelCase. The transformation is done both at runtime and type level.
+ * A strongly typed function that shallowly transforms the keys of an object to camelCase. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
  * @example camelKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { fooBar: { 'fizz-buz': true } }
@@ -105,7 +105,7 @@ type DeepPascalKeys<T> = T extends [any, ...any]
       [K in keyof T as PascalCase<Is<K, string>>]: DeepPascalKeys<T[K]>
     }
 /**
- * Transforms the keys of an Record to PascalCase.
+ * Shallowly transforms the keys of an Record to PascalCase.
  * T: the type of the Record to transform.
  */
 type PascalKeys<T> = T extends []
@@ -121,7 +121,7 @@ function deepPascalKeys<T>(obj: T): DeepPascalKeys<T> {
   return deepTransformKeys(obj, toPascalCase) as never
 }
 /**
- * A strongly typed function that transforms the keys of an object to pascal case. The transformation is done both at runtime and type level.
+ * A strongly typed function that shallowly transforms the keys of an object to pascal case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
  * @example pascalKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { FooBar: { 'fizz-buzz': true } }
@@ -142,7 +142,7 @@ type DeepKebabKeys<T> = T extends [any, ...any]
       [K in keyof T as KebabCase<Is<K, string>>]: DeepKebabKeys<T[K]>
     }
 /**
- * Transforms the keys of an Record to kebab-case.
+ * Shallowly transforms the keys of an Record to kebab-case.
  * T: the type of the Record to transform.
  */
 type KebabKeys<T> = T extends []
@@ -160,7 +160,7 @@ function deepKebabKeys<T>(obj: T): DeepKebabKeys<T> {
   return deepTransformKeys(obj, toKebabCase) as never
 }
 /**
- * A strongly typed function that transforms the keys of an object to kebab-case. The transformation is done both at runtime and type level.
+ * A strongly typed function that shallowly transforms the keys of an object to kebab-case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
  * @example kebabKeys({ fooBar: { fizzBuzz: true } }) // { 'foo-bar': { fizzBuzz: true } }
@@ -181,7 +181,7 @@ type DeepSnakeKeys<T> = T extends [any, ...any]
       [K in keyof T as SnakeCase<Is<K, string>>]: DeepSnakeKeys<T[K]>
     }
 /**
- * Transforms the keys of an Record to snake_case.
+ * Shallowly transforms the keys of an Record to snake_case.
  * T: the type of the Record to transform.
  */
 type SnakeKeys<T> = T extends []
@@ -198,7 +198,7 @@ function deepSnakeKeys<T>(obj: T): DeepSnakeKeys<T> {
   return deepTransformKeys(obj, toSnakeCase) as never
 }
 /**
- * A strongly typed function that transforms the keys of an object to snake_case. The transformation is done both at runtime and type level.
+ * A strongly typed function that shallowly the keys of an object to snake_case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
  * @example snakeKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { 'foo_bar': { 'fizz-buzz': true } }
@@ -219,7 +219,7 @@ type DeepConstantKeys<T> = T extends [any, ...any]
       [K in keyof T as ConstantCase<Is<K, string>>]: DeepConstantKeys<T[K]>
     }
 /**
- * Transforms the keys of an Record to CONSTANT_CASE.
+ * Shallowly transforms the keys of an Record to CONSTANT_CASE.
  * T: the type of the Record to transform.
  */
 type ConstantKeys<T> = T extends []
@@ -235,7 +235,7 @@ function deepConstantKeys<T>(obj: T): DeepConstantKeys<T> {
   return deepTransformKeys(obj, toConstantCase) as never
 }
 /**
- * A strongly typed function that transforms the keys of an object to CONSTANT_CASE. The transformation is done both at runtime and type level.
+ * A strongly typed function that shallowly transforms the keys of an object to CONSTANT_CASE. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @returns the transformed object.
  * @example constantKeys({ 'foo-bar': { 'fizz-buzz': true } }) // { FOO_BAR: { 'fizz-buzz': true } }
@@ -260,7 +260,7 @@ type DeepDelimiterKeys<T, D extends string> = T extends [any, ...any]
       >
     }
 /**
- * Transforms the keys of an Record to a custom delimiter case.
+ * Shallowly transforms the keys of an Record to a custom delimiter case.
  * T: the type of the Record to transform.
  * D: the delimiter to use.
  */
@@ -283,11 +283,11 @@ function deepDelimiterKeys<T, D extends string>(
   ) as never
 }
 /**
- * A strongly typed function that recursively the keys of an object to a custom delimiter case. The transformation is done both at runtime and type level.
+ * A strongly typed function that shallowly the keys of an object to a custom delimiter case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @param delimiter the delimiter to use.
  * @returns the transformed object.
- * @example deepDelimiterKeys({ 'foo-bar': { 'fizz-buzz': true } }, '.') // { 'foo.bar': { 'fizz.buzz': true } }
+ * @example delimiterKeys({ 'foo-bar': { 'fizz-buzz': true } }, '.') // { 'foo.bar': { 'fizz.buzz': true } }
  */
 function delimiterKeys<T, D extends string>(
   obj: T,

--- a/src/key-casing.ts
+++ b/src/key-casing.ts
@@ -283,7 +283,7 @@ function deepDelimiterKeys<T, D extends string>(
   ) as never
 }
 /**
- * A strongly typed function that shallowly the keys of an object to a custom delimiter case. The transformation is done both at runtime and type level.
+ * A strongly typed function that shallowly transforms the keys of an object to a custom delimiter case. The transformation is done both at runtime and type level.
  * @param obj the object to transform.
  * @param delimiter the delimiter to use.
  * @returns the transformed object.


### PR DESCRIPTION
Hi,

Thanks for this useful package! As I was investigating a migration of my work codebase to this, I faced the need to have "not deep" version of the key casing functions.

This PR implements this. Nothing very complex here, it's all simplified versions of the deep functions.




