### PR TITLE
Add a charAt method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install string-ts
   - [trim](#trim)
   - [trimStart](#trimstart)
   - [trimEnd](#trimend)
+  - [chartAt](#charat)
   - [join](#join)
   - [replace](#replace)
   - [replaceAll](#replaceall)
@@ -135,6 +136,17 @@ import { trimEnd } from 'string-ts';
 const str = '  hello world  ';
 const result = trimEnd(str);
 //    ^ '  hello world'
+```
+
+### charAt
+This function is a strongly-typed counterpart of `String.prototype.charAt`.
+
+```ts
+import { charAt } from 'string-ts';
+
+const str = 'hello world';
+const result = charAt(str, 6);
+//    ^ 'w'
 ```
 
 ### join
@@ -380,6 +392,7 @@ Uppercase<'hello world'> // 'HELLO WORLD'
 ### General Type utilities from this library
 ```ts
 St.Words<'hello-world'> // ['hello', 'world']
+St.CharAt<'hello world', 6> // 'w'
 St.Join<['hello', 'world'], '-'> // 'hello-world'
 St.Replace<'hello-world', 'l', '1'> // 'he1lo-world'
 St.ReplaceAll<'hello-world', 'l', '1'> // 'he11o-wor1d'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // PRIMITIVES
 export type {
+  CharAt,
   Join,
   Replace,
   ReplaceAll,
@@ -9,6 +10,7 @@ export type {
   Trim,
 } from './primitives'
 export {
+  charAt,
   join,
   replace,
   replaceAll,

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -23,9 +23,19 @@ namespace TypeTests {
   type test7 = Expect<
     Equal<Subject.Split<'some nice string', ' '>, ['some', 'nice', 'string']>
   >
+  type test8 = Expect<Equal<Subject.CharAt<'some nice string', 5>, 'n'>>
 }
 
 describe('primitives', () => {
+  describe('charAt', () => {
+    test('should get the character of a string at the given index in both type and runtime level', () => {
+      const data = 'some nice string'
+      const result = subject.charAt(data, 5)
+      expect(result).toEqual('n')
+      type test = Expect<Equal<typeof result, 'n'>>
+    })
+  })
+
   describe('join', () => {
     test('should join words in both type level and runtime level', () => {
       const data = ['a', 'b', 'c'] as const

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,8 +1,26 @@
-import type { Is } from './utils'
+/**
+ * Gets the character at the given index.
+ * T: The string to get the character from.
+ * index: The index of the character.
+ */
+type CharAt<T extends string, index extends number> = Split<T, ''>[index]
+/**
+ * A strongly typed version of `String.prototype.charAt`.
+ * @param str the string to get the character from.
+ * @param index the index of the character.
+ * @returns the character in both type level and runtime.
+ * @example charAt('hello world', 6) // 'w'
+ */
+function charAt<T extends string, I extends number>(
+  str: T,
+  index: I,
+): CharAt<T, I> {
+  return str.charAt(index)
+}
 
 /**
  * Joins a tuple of strings with the given delimiter.
- * T: The current tuple of strings.
+ * T: The tuple of strings to join.
  * delimiter: The delimiter.
  */
 type Join<
@@ -171,5 +189,14 @@ function trim<T extends string>(str: T) {
   return str.trim() as Trim<T>
 }
 
-export type { Join, Replace, ReplaceAll, Split, TrimStart, TrimEnd, Trim }
-export { join, replace, replaceAll, split, trim, trimStart, trimEnd }
+export type {
+  CharAt,
+  Join,
+  Replace,
+  ReplaceAll,
+  Split,
+  TrimStart,
+  TrimEnd,
+  Trim,
+}
+export { charAt, join, replace, replaceAll, split, trim, trimStart, trimEnd }


### PR DESCRIPTION
It adds the strongly-typed version of `String.prototype.charAt` function.