### PR TITLE
Improve inference of `join` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This function is a strongly-typed counterpart of `Array.prototype.join`.
 ```ts
 import { join } from 'string-ts';
 
-const str = ['hello', 'world'] as ['hello', 'world'];
+const str = ['hello', 'world'] as const;
 const result = join(str, ' ');
 //    ^ 'hello world'
 ```

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -28,7 +28,7 @@ namespace TypeTests {
 describe('primitives', () => {
   describe('join', () => {
     test('should join words in both type level and runtime level', () => {
-      const data: ['a', 'b', 'c'] = ['a', 'b', 'c']
+      const data = ['a', 'b', 'c'] as const
       const result = subject.join(data, '-')
       expect(result).toEqual('a-b-c')
       type test = Expect<Equal<typeof result, 'a-b-c'>>

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,4 +1,4 @@
-import { Is } from './utils'
+import type { Is } from './utils'
 
 /**
  * Joins a tuple of strings with the given delimiter.
@@ -6,14 +6,17 @@ import { Is } from './utils'
  * delimiter: The delimiter.
  */
 type Join<
-  T extends string[],
+  T extends readonly string[],
   delimiter extends string = '',
 > = string[] extends T
   ? string // Avoid spending resources on a wide type
-  : T extends [infer first, ...infer rest]
+  : T extends readonly [
+      infer first extends string,
+      ...infer rest extends string[],
+    ]
   ? rest extends []
     ? first
-    : `${Is<first, string>}${delimiter}${Join<Is<rest, string[]>, delimiter>}`
+    : `${first}${delimiter}${Join<rest, delimiter>}`
   : ''
 
 /**
@@ -23,7 +26,7 @@ type Join<
  * @returns the joined string in both type level and runtime.
  * @example join(['hello', 'world'], '-') // 'hello-world'
  */
-function join<T extends string[], D extends string = ''>(
+function join<const T extends readonly string[], D extends string = ''>(
   tuple: T,
   delimiter?: D,
 ) {


### PR DESCRIPTION
This PR is an improvement to the `join` function by @mattpocock <3

Now we don't need to explicitly cast the tuple type as long as we make an array `as const`.
Check the README and tests diff for clarification.