### PR TITLE
Fixes a bug where split by empty string would add an extra empty char to the resulting tuple

### DIFF
--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -77,6 +77,16 @@ describe('primitives', () => {
       expect(result).toEqual(['some', 'nice', 'string'])
       type test = Expect<Equal<typeof result, ['some', 'nice', 'string']>>
     })
+
+    test('should no add extra characters when splitting by empty string', () => {
+      const data = 'hello'
+      const result = subject.split(data, '')
+      expect(result).toEqual(['h', 'e', 'l', 'l', 'o'])
+      type test = Expect<Equal<typeof result, ['h', 'e', 'l', 'l', 'o']>>
+
+      expect(subject.split('', '')).toEqual([])
+      type test2 = Expect<Equal<Subject.Split<''>, []>>
+    })
   })
 
   test('trimStart', () => {

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -126,9 +126,11 @@ function replaceAll<T extends string, S extends string, R extends string = ''>(
  */
 type Split<
   T,
-  delimiter extends string,
+  delimiter extends string = '',
 > = T extends `${infer first}${delimiter}${infer rest}`
   ? [first, ...Split<rest, delimiter>]
+  : T extends ''
+  ? []
   : [T]
 /**
  * A strongly typed version of `String.prototype.split`.


### PR DESCRIPTION
This PR fixes #20 .

It also adds a regression test just in case.