### PR TITLE
feat: polyfill for replaceAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ const result = length(str)
 
 This function is a strongly-typed counterpart of `String.prototype.replace`.
 
+_Warning: this is a partial implementation as we don't support Regex._
+
 ```ts
 import { replace } from 'string-ts'
 
@@ -214,6 +216,9 @@ const result = replace(str, '-', ' ')
 ### replaceAll
 
 This function is a strongly-typed counterpart of `String.prototype.replaceAll`.
+It also has a polyfill for runtimes older than ES2021.
+
+_Warning: this is a partial implementation as we don't support Regex._
 
 ```ts
 import { replaceAll } from 'string-ts'
@@ -227,7 +232,7 @@ const result = replaceAll(str, '-', ' ')
 
 This function is a strongly-typed counterpart of `String.prototype.slice`.
 
-_Warning: due to TS limitations - for now - we ignore the second argument (endIndex) if the first (startIndex) is negative and we also don't support a negative endIndex._
+_Warning: this is a partial implementation. For now we ignore the second argument (endIndex) if the first (startIndex) is negative and we also don't support a negative endIndex._
 
 ```ts
 import { slice } from 'string-ts'

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type * as Subject from './primitives'
 import * as subject from './primitives'
 
@@ -29,6 +30,10 @@ namespace TypeTests {
   >
   type test10 = Expect<Equal<Subject.Length<'some nice string'>, 16>>
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('primitives', () => {
   describe('charAt', () => {
@@ -86,6 +91,25 @@ describe('primitives', () => {
       const result = subject.replaceAll(data, ' ', '@')
       expect(result).toEqual('some@nice@string')
       type test = Expect<Equal<typeof result, 'some@nice@string'>>
+    })
+  })
+
+  describe('replaceAll polyfill', () => {
+    const replaceAll = String.prototype.replaceAll
+    beforeAll(() => {
+      // @ts-ignore
+      String.prototype.replaceAll = undefined
+    })
+
+    afterAll(() => {
+      String.prototype.replaceAll = replaceAll
+    })
+    test('it works through a polyfill', () => {
+      const spy = vi.spyOn(String.prototype, 'replace')
+      const data = 'some nice string'
+      const result = subject.replaceAll(data, ' ', '@')
+      expect(result).toEqual('some@nice@string')
+      expect(spy).toHaveBeenCalledWith(/ /g, '@')
     })
   })
 

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -80,6 +80,13 @@ describe('primitives', () => {
       expect(result).toEqual('somenicestring')
       type test = Expect<Equal<typeof result, 'somenicestring'>>
     })
+
+    test('accepts an argument for the replacement', () => {
+      const data = 'some nice string'
+      const result = subject.replaceAll(data, ' ', '@')
+      expect(result).toEqual('some@nice@string')
+      type test = Expect<Equal<typeof result, 'some@nice@string'>>
+    })
   })
 
   describe('slice', () => {

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -92,13 +92,9 @@ type Replace<
 function replace<T extends string, S extends string, R extends string = ''>(
   sentence: T,
   lookup: S,
-  replacement?: R,
+  replacement: R = '' as R,
 ) {
-  return sentence.replace(lookup, replacement ?? ('' as const)) as Replace<
-    T,
-    S,
-    R
-  >
+  return sentence.replace(lookup, replacement) as Replace<T, S, R>
 }
 
 /**
@@ -126,13 +122,15 @@ type ReplaceAll<
 function replaceAll<T extends string, S extends string, R extends string = ''>(
   sentence: T,
   lookup: S,
-  replacement?: R,
+  replacement: R = '' as R,
 ) {
   // Only supported in ES2021+
-  return sentence.replaceAll(
-    lookup,
-    replacement ?? ('' as const),
-  ) as ReplaceAll<T, S, R>
+  if (typeof sentence.replaceAll === 'function') {
+    return sentence.replaceAll(lookup, replacement) as ReplaceAll<T, S, R>
+  }
+
+  const regex = new RegExp(lookup, 'g')
+  return sentence.replace(regex, replacement) as ReplaceAll<T, S, R>
 }
 
 // TODO: this is not equivalent to the native slice but it is as far as I got with Type level arithmetic. When the startIndex is negative, the endIndex is gonna be considered as undefined.


### PR DESCRIPTION
This PR adds a polyfill to `replaceAll` function so it won't break the runtime due to `String.prototype.replaceAll` in versions older than ES2021.