### PR TITLE
fix: Fix slice negative start and end indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bun.lockb
 .vscode/
 node_modules
 dist/

--- a/README.md
+++ b/README.md
@@ -244,8 +244,6 @@ const result = replaceAll(str, '-', ' ')
 
 This function is a strongly-typed counterpart of `String.prototype.slice`.
 
-_Warning: this is a partial implementation. For now we ignore the second argument (endIndex) if the first (startIndex) is negative and we also don't support a negative endIndex._
-
 ```ts
 import { slice } from 'string-ts'
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsup ./src/index.ts --format esm,cjs --dts",
     "dev": "tsup ./src/index.ts --format esm,cjs --watch --dts",
     "lint": "eslint *.ts*",
-    "tsc": "tsc",
+    "tsc": "tsc --noEmit",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -140,12 +140,28 @@ describe('primitives', () => {
       type test = Expect<Equal<typeof result, 'dog.'>>
     })
 
+    test('should allow a negative endIndex', () => {
+      const result = subject.slice(str, 0, -5)
+      expect(result).toEqual('The quick brown fox jumps over the lazy')
+      type test = Expect<
+        Equal<typeof result, 'The quick brown fox jumps over the lazy'>
+      >
+    })
+
     test('should slice a string from the end with a negative startIndex to a negative endIndex', () => {
       const result = subject.slice(str, -9, -5)
-      expect(result).toEqual('lazy dog.')
-      type test = Expect<Equal<typeof result, 'lazy dog.'>>
-      // TODO: figure out how to deal with negative endIndex, this should be the expected result
-      // type test = Expect<Equal<typeof result, 'lazy'>>
+      expect(result).toEqual('lazy')
+      type test = Expect<Equal<typeof result, 'lazy'>>
+    })
+
+    test('should return an empty string if endIndex is lower than startIndex', () => {
+      const result = subject.slice(str, -9, -10)
+      expect(result).toEqual('')
+      type test = Expect<Equal<typeof result, ''>>
+
+      const result2 = subject.slice(str, 9, 1)
+      expect(result2).toEqual('')
+      type test2 = Expect<Equal<typeof result2, ''>>
     })
   })
 

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -149,13 +149,11 @@ function replaceAll<T extends string, S extends string, R extends string = ''>(
   return sentence.replace(regex, replacement) as ReplaceAll<T, S, R>
 }
 
-// TODO: this is not equivalent to the native slice but it is as far as I got with Type level arithmetic. When the startIndex is negative, the endIndex is gonna be considered as undefined.
 /**
  * Slices a string from a startIndex to an endIndex.
  * T: The string to slice.
  * startIndex: The start index.
  * endIndex: The end index.
- * @warning 🚨 it doesn't work exactly like the native slice as it will ignore the end index if start index is negative
  */
 type Slice<
   T extends string,
@@ -167,15 +165,13 @@ type Slice<
       ? ''
       : `${head}${Slice<
           rest,
-          0,
-          endIndex extends -1 ? -1 : Math.Subtract<endIndex, 1>
+          Math.Subtract<Math.GetPositiveIndex<T, startIndex>, 1>,
+          Math.Subtract<Math.GetPositiveIndex<T, endIndex>, 1>
         >}`
     : `${Slice<
         rest,
         Math.Subtract<Math.GetPositiveIndex<T, startIndex>, 1>,
-        Math.IsPositive<startIndex> extends true
-          ? Math.Subtract<endIndex, 1>
-          : Split<T>['length'] // TODO: figure out how to deal with negative endIndex
+        Math.Subtract<Math.GetPositiveIndex<T, endIndex>, 1>
       >}`
   : ''
 /**
@@ -185,15 +181,13 @@ type Slice<
  * @param end the end index.
  * @returns the sliced string in both type level and runtime.
  * @example slice('hello world', 6) // 'world'
- * @warning 🚨 it doesn't work exactly like the native slice as it will ignore the end index if start index is negative
  */
 function slice<
   T extends string,
   const S extends number = 0,
   const E extends number = Split<T>['length'],
 >(str: T, start: S = 0 as S, end: E = str.length as E) {
-  // TODO: figure out how to deal with negative endIndex
-  return str.slice(start, start < 0 ? undefined : end) as Slice<T, S, E>
+  return str.slice(start, end) as Slice<T, S, E>
 }
 
 /**

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -64,9 +64,9 @@ type Join<
  */
 function join<const T extends readonly string[], D extends string = ''>(
   tuple: T,
-  delimiter?: D,
+  delimiter: D = '' as D,
 ) {
-  return tuple.join(delimiter ?? ('' as const)) as Join<T, D>
+  return tuple.join(delimiter) as Join<T, D>
 }
 
 /**
@@ -184,8 +184,8 @@ type Slice<
  */
 function slice<
   T extends string,
-  const S extends number = 0,
-  const E extends number = Split<T>['length'],
+  S extends number = 0,
+  E extends number = Split<T>['length'],
 >(str: T, start: S = 0 as S, end: E = str.length as E) {
   return str.slice(start, end) as Slice<T, S, E>
 }
@@ -210,8 +210,11 @@ type Split<
  * @returns the splitted string in both type level and runtime.
  * @example split('hello world', ' ') // ['hello', 'world']
  */
-function split<T extends string, D extends string = ''>(str: T, delimiter?: D) {
-  return str.split(delimiter ?? ('' as const)) as Split<T, D>
+function split<T extends string, D extends string = ''>(
+  str: T,
+  delimiter: D = '' as D,
+) {
+  return str.split(delimiter) as Split<T, D>
 }
 
 /**


### PR DESCRIPTION
In this PR I was able to solve the puzzle of negative indexes in `slice` method  - which was actually much simpler than I thought.