### PR TITLE
feat: add truncate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ It also only work with common ASCII characters characters. We don't plan to supp
   - [toSnakeCase](#tosnakecase)
   - [toTitleCase](#totitlecase)
   - [words](#words)
+  - [truncate](#truncate)
 - [Strongly-typed shallow transformation of objects](#strongly-typed-shallow-transformation-of-objects)
   - [camelKeys](#camelkeys)
   - [constantKeys](#constantkeys)
@@ -506,6 +507,19 @@ const result = words(str)
 //    ^ ['20', 'some', 'Very', 'weird', 'String']
 ```
 
+### truncate
+
+This function truncates string if it's longer than the given maximum string length. The last characters of the truncated string are replaced with the omission string which defaults to "...".
+
+
+```ts
+import { truncate } from 'string-ts'
+
+const str = '-20someVery-weird String'
+const result = truncate(str, 8)
+//    ^ '-20so...'
+```
+
 ## Strongly-typed shallow transformation of objects
 
 ### camelKeys
@@ -739,6 +753,7 @@ St.StartsWith<'abc', 'a'> // true
 St.TrimEnd<' hello world '> // ' hello world'
 St.TrimStart<' hello world '> // 'hello world '
 St.Words<'hello-world'> // ['hello', 'world']
+St.Truncate<'hello world', 9, '[...]'> // 'hello[...]
 ```
 
 ### Casing type utilities

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,10 @@ export type {
   IsSpecial,
   IsUpper,
   Separator,
+  Truncate,
   Words,
 } from './utils'
-export { words } from './utils'
+export { truncate, words } from './utils'
 
 // CASING
 export type {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -39,6 +39,19 @@ namespace TypeChecks {
   type test30 = Expect<Equal<Subject.IsSpecial<' '>, false>>
   type test31 = Expect<Equal<Subject.IsSpecial<'*'>, true>>
   type test32 = Expect<Equal<Subject.IsSpecial<'_'>, false>>
+
+  type test33 = Expect<Equal<Subject.Truncate<'Hello, world', 9>, 'Hello,...'>>
+  type test34 = Expect<
+    Equal<Subject.Truncate<'Hello, world', 12>, 'Hello, world'>
+  >
+  type test35 = Expect<Equal<Subject.Truncate<'Hello, world', 2>, '...'>>
+  type test36 = Expect<
+    Equal<Subject.Truncate<'Hello, world', 9, '[...]'>, 'Hell[...]'>
+  >
+  type test37 = Expect<Equal<Subject.Truncate<'Hello, world', -1>, '...'>>
+  type test38 = Expect<
+    Equal<Subject.Truncate<'Hello, world', 0, '[...]'>, '[...]'>
+  >
 }
 
 type Mutable<Type> = {
@@ -98,5 +111,40 @@ describe('words', () => {
     const result = subject.words(' someWeird-cased$*String1986Foo Bar ')
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, Mutable<typeof expected>>>
+  })
+
+  test('truncate small sentence does nothing', () => {
+    const expected = 'Hello' as const
+    const result = subject.truncate('Hello', 9)
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('truncate big sentence truncate', () => {
+    const expected = 'Hello ...' as const
+    const result = subject.truncate('Hello world', 9)
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('truncate with negative integer does truncate', () => {
+    const expected = '...' as const
+    const result = subject.truncate('Hello world', -1)
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('truncate big sentence with specified omission', () => {
+    const expected = 'Hello[...]' as const
+    const result = subject.truncate('Hello world', 10, '[...]')
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
+  })
+
+  test('truncate small sentence with specified omission', () => {
+    const expected = 'Hello' as const
+    const result = subject.truncate('Hello', 10, '[...]')
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, typeof expected>>
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { Math } from './math'
+import type { Slice, Split } from './primitives'
 import type { Drop, DropSuffix } from './internals'
 
 type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
@@ -135,6 +137,43 @@ function words<T extends string>(sentence: T): Words<T> {
     .split(/\s+/g) as Words<T>
 }
 
+/**
+ * Truncate a string if it's longer than the given maximum length.
+ * The last characters of the truncated string are replaced with the omission string which defaults to "...".
+ */
+type Truncate<
+  T extends string,
+  Size extends number,
+  Omission extends string = '...',
+> = Math.IsNegative<Size> extends true
+  ? Omission
+  : Math.Subtract<Split<T>['length'], Size> extends 0
+  ? T
+  : `${Slice<T, 0, Math.Subtract<Size, Split<Omission>['length']>>}${Omission}`
+
+/**
+ * A strongly typed function to truncate a string .
+ * if it's longer than the given maximum string length.
+ * @param sentence the sentence to extract the words from.
+ * @param length the maximum length of the string.
+ * @param omission the string to append to the end of the truncated string.
+ * @returns the truncated string
+ * @example truncate('Hello, World', 8) // 'Hello...'
+ */
+function truncate<T extends string, S extends number, P extends string = '...'>(
+  sentence: T,
+  length: S,
+  omission = '...' as P,
+): Truncate<T, S, P> {
+  if (length <= 0) return omission as Truncate<T, S, P>
+  if (sentence.length <= length) return sentence as Truncate<T, S, P>
+  if (sentence.length <= omission.length) return omission as Truncate<T, S, P>
+  return `${sentence.slice(
+    0,
+    length - omission.length,
+  )}${omission}` as Truncate<T, S, P>
+}
+
 export type {
   Digit,
   Is,
@@ -146,6 +185,7 @@ export type {
   IsUpper,
   Separator,
   TupleOf,
+  Truncate,
   Words,
 }
-export { words }
+export { truncate, words }


### PR DESCRIPTION
roadmap mention we might want to implement a `truncate` function, similar to lodash one, here is a proposition.

I _think_ it behave as the lodash one, except for the `separator` option.

I did not add the `separator` option, because:
- it seemed hard :)
- I don't really know if the complexity is worth it. Lodash use an object as an option so it's quite easy to have multiple params (length, omission, separator) but if we stick to raw input then I think the interface would be quite polluted.
