### PR TITLE
Fix: Handle upper/lower case with digits

### DIFF
--- a/src/deep-key-casing.test.ts
+++ b/src/deep-key-casing.test.ts
@@ -110,10 +110,14 @@ test('deepSnakeKeys', () => {
   const expected = {
     some: { deep_nested: { value: true } },
     other_value: true,
+    prev_2: true,
+    pre_v2: true,
   }
   const result = subject.deepSnakeKeys({
     some: { deepNested: { value: true } },
     otherValue: true,
+    prev2: true,
+    preV2: true,
   })
   expect(result).toEqual(expected)
   type test = Expect<Equal<typeof result, typeof expected>>

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -26,8 +26,15 @@ describe('words', () => {
   })
 
   test('it splits words at digits', () => {
-    const expected = ['2', 'Weird', 'Cased', '1986', 'Foo'] as const
-    const result = subject.words('2WeirdCased1986Foo')
+    const expected = ['2', 'Weird', 'Cased', '1986', 'Foo', 'V2'] as const
+    const result = subject.words('2WeirdCased1986FooV2')
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, Mutable<typeof expected>>>
+  })
+
+  test('it correctly splits upper vs lower words with digits', () => {
+    const expected = ['love', '2', 'be', 'Pre', 'V2', 'Alpha'] as const
+    const result = subject.words('love2bePreV2Alpha')
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, Mutable<typeof expected>>>
   })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,9 +25,12 @@ type Words<
     : prev extends ''
     ? // Start of sentence, start a new word
       Reject<Words<rest, curr, curr>, ''>
-    : [false, true] extends [IsDigit<prev>, IsDigit<curr>]
-    ? // Step 2: From non-digit to digit
+    : [true, true] extends [IsLower<prev>, IsDigit<curr>]
+    ? // Step 2.a: Non-digit to digit: Split when from lower-case
       [word, ...Words<rest, curr, curr>]
+    : [true, true] extends [IsUpper<prev>, IsDigit<curr>]
+    ? // Step 2.b: Non-digit to digit: Continue when from upper-case
+      Reject<Words<rest, `${word}${curr}`, curr>, ''>
     : [true, false] extends [IsDigit<prev>, IsDigit<curr>]
     ? // Step 3: From digit to non-digit
       [word, ...Words<rest, curr, curr>]
@@ -60,12 +63,13 @@ type Words<
 function words<T extends string>(sentence: T): Words<T> {
   return sentence
     .replace(SEPARATOR_REGEX, ' ') // Step 1: Remove separators
-    .replace(/([a-zA-Z])([0-9])/g, '$1 $2') // Step 2: From non-digit to digit
-    .replace(/([0-9])([a-zA-Z])/g, '$1 $2') // Step 3: From digit to non-digit
-    .replace(/([a-zA-Z0-9_\-./])([^a-zA-Z0-9_\-./])/g, '$1 $2') // Step 4: From non-special to special
-    .replace(/([^a-zA-Z0-9_\-./])([a-zA-Z0-9_\-./])/g, '$1 $2') // Step 5: From special to non-special
-    .replace(/([a-z])([A-Z])/g, '$1 $2') // Step 6: From lower to upper
-    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2') // Step 7: From upper to upper and lower
+    .replace(/([a-z])([0-9])/g, '$1 $2') // Step 2: From lower-case non-digit to digit
+    .replace(/([A-Z])([0-9])/g, '$1$2') // Step 3: From upper-case non-digit to digit
+    .replace(/([0-9])([a-zA-Z])/g, '$1 $2') // Step 4: From digit to non-digit
+    .replace(/([a-zA-Z0-9_\-./])([^a-zA-Z0-9_\-./])/g, '$1 $2') // Step 5: From non-special to special
+    .replace(/([^a-zA-Z0-9_\-./])([a-zA-Z0-9_\-./])/g, '$1 $2') // Step 6: From special to non-special
+    .replace(/([a-z])([A-Z])/g, '$1 $2') // Step 7: From lower to upper
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2') // Step 8: From upper to upper and lower
     .trim() // Step 8: Trim the last word
     .split(/\s+/g) as Words<T>
 }

--- a/src/utils.types.test.ts
+++ b/src/utils.types.test.ts
@@ -3,7 +3,7 @@ import type * as Subject from './utils'
 namespace WordsTests {
   type test1 = Expect<
     Equal<
-      Subject.Words<' someWeird-cased$*String1986Foo Bar obj.items[0]'>,
+      Subject.Words<' someWeird-cased$*String1986Foo Bar obj.items[0]prev2PreV2'>,
       [
         'some',
         'Weird',
@@ -16,6 +16,10 @@ namespace WordsTests {
         'obj',
         'items',
         '0',
+        'prev',
+        '2',
+        'Pre',
+        'V2',
       ]
     >
   >


### PR DESCRIPTION
This PR fixes this issue: https://github.com/gustavoguichard/string-ts/issues/54

Following [this Ruby style guide](https://github.com/rubocop/ruby-style-guide#snake-case-symbols-methods-vars-with-numbers), snake_case should not separate numbers from letters. So the correct would be "api_v2" instead of "api_v_2".

By the current `Words` type definition, the `deepSnakeCase()` function is transforming "apiV2" to "api_v_2", instead of "api_v2". This PR fixes this.