### PR TITLE
ci: test output against previous version of typescript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,45 @@ on:
   pull_request:
 
 jobs:
+  typecheck-outputs:
+    name: 🚚 Typecheck Outputs / ${{ matrix.typescript-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typescript-version:
+          - '~5.2.0'
+          - '~5.1.0'
+            # We use features that were added in v5.0 of typescript, so that is
+            # the lowest we can go here. This also means this is the lowest
+            # version we support. When this value changes in the future it needs
+            # to be communicated to the users.
+          - '~5.0.0'
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: 🪡 Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: 📦 Install Dependencies
+        run: npm install
+
+      # Order is important here, we build with the typescript version defined
+      # in package.json, before we overrite it for the tests.
+      - name: 🏗️ Build
+        run: npm run build
+
+      - name: 📘 Install Typescript
+        run: npm install --dev typescript@${{ matrix.typescript-version }}
+
+      - name: 🔎 Type check
+        run: npm run tsc:dist
+
+
   test:
     name: Run tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "tsup ./src/index.ts --format esm,cjs --watch --dts",
     "lint": "eslint *.ts*",
     "tsc": "tsc --noEmit",
+    "tsc:dist": "tsc --project tsconfig.dist.json",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "include": ["dist"],
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "skipDefaultLibCheck": false,
+    "skipLibCheck": false
+  }
+}


### PR DESCRIPTION
I think we need to differentiate the typescript version we use in our source code from the typescript version we officially support.
Right now we use version 5.1 in our sources - but we support typescript 5.0. This new CI checks ensure that we continue to support typescript 5.0 in future.


