### PR TITLE
fix: handle non-literal strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,8 @@ export { trimStart } from './native/trim-start.js'
 export type { TrimEnd } from './native/trim-end.js'
 export { trimEnd } from './native/trim-end.js'
 export type { Trim } from './native/trim.js'
-
 export { trim } from './native/trim.js'
+
 export { toLowerCase } from './native/to-lower-case.js'
 export { toUpperCase } from './native/to-upper-case.js'
 

--- a/src/internal/internals.test.ts
+++ b/src/internal/internals.test.ts
@@ -2,23 +2,34 @@ import * as subject from './internals'
 import type * as Subject from './internals'
 
 namespace Internals {
-  type test = Expect<
+  type testPascalCaseAll1 = Expect<
     Equal<
       Subject.PascalCaseAll<['one', 'two', 'three']>,
       ['One', 'Two', 'Three']
     >
   >
+  type testPascalCaseAll2 = Expect<
+    Equal<Subject.PascalCaseAll<string[]>, string[]>
+  >
 
-  type test1 = Expect<
+  type testReject1 = Expect<
     Equal<
       Subject.Reject<['one', '', 'two', '', 'three'], ''>,
       ['one', 'two', 'three']
     >
   >
 
-  type test2 = Expect<Equal<Subject.DropSuffix<'helloWorld', 'World'>, 'hello'>>
+  type testDropSuffix1 = Expect<
+    Equal<Subject.DropSuffix<'helloWorld', 'World'>, 'hello'>
+  >
+  type testDropSuffix2 = Expect<
+    Equal<Subject.DropSuffix<string, 'World'>, string>
+  >
+  type testDropSuffix3 = Expect<
+    Equal<Subject.DropSuffix<'helloWorld', string>, string>
+  >
 
-  type test3 = Expect<Equal<Subject.TupleOf<3, ' '>, [' ', ' ', ' ']>>
+  type testTupleOf1 = Expect<Equal<Subject.TupleOf<3, ' '>, [' ', ' ', ' ']>>
 }
 
 describe('typeOf', () => {

--- a/src/internal/internals.ts
+++ b/src/internal/internals.ts
@@ -45,7 +45,11 @@ type Reject<tuple, cond, output extends any[] = []> = tuple extends [
 type DropSuffix<
   sentence extends string,
   suffix extends string,
-> = sentence extends `${infer rest}${suffix}` ? rest : sentence
+> = string extends sentence | suffix
+  ? string
+  : sentence extends `${infer rest}${suffix}`
+  ? rest
+  : sentence
 
 /**
  * Returns a tuple of the given length with the given type.

--- a/src/internal/math.test.ts
+++ b/src/internal/math.test.ts
@@ -4,6 +4,8 @@ namespace MathTest {
   // NOTE: `Subtract` only supports non-negative integers
   type testSubtract1 = Expect<Equal<Math.Subtract<2, 1>, 1>>
   type testSubtract2 = Expect<Equal<Math.Subtract<2, 2>, 0>>
+  type testSubtract3 = Expect<Equal<Math.Subtract<number, 2>, number>>
+  type testSubtract4 = Expect<Equal<Math.Subtract<2, number>, number>>
 
   type testIsNegative1 = Expect<Equal<Math.IsNegative<2>, false>>
   type testIsNegative2 = Expect<Equal<Math.IsNegative<0>, false>>
@@ -13,9 +15,13 @@ namespace MathTest {
   type testAbs2 = Expect<Equal<Math.Abs<1>, 1>>
   type testAbs3 = Expect<Equal<Math.Abs<0>, 0>>
   type testAbs4 = Expect<Equal<Math.Abs<-0>, 0>>
+  type testAbs5 = Expect<Equal<Math.Abs<number>, number>>
 
   type testGetPositiveIndex1 = Expect<
     Equal<Math.GetPositiveIndex<'abc', -1>, 2>
+  >
+  type testGetPositiveIndex2 = Expect<
+    Equal<Math.GetPositiveIndex<string, -1>, number>
   >
 }
 

--- a/src/internal/math.ts
+++ b/src/internal/math.ts
@@ -2,17 +2,24 @@ import type { Length } from '../native/length.js'
 import type { TupleOf } from './internals.js'
 
 namespace Math {
-  export type Subtract<
-    A extends number,
-    B extends number,
-  > = TupleOf<A> extends [...infer U, ...TupleOf<B>] ? U['length'] : 0
+  export type Subtract<A extends number, B extends number> = number extends
+    | A
+    | B
+    ? number
+    : TupleOf<A> extends [...infer U, ...TupleOf<B>]
+    ? U['length']
+    : 0
 
-  export type IsNegative<T extends number> = `${T}` extends `-${number}`
+  export type IsNegative<T extends number> = number extends T
+    ? boolean
+    : `${T}` extends `-${number}`
     ? true
     : false
 
-  export type Abs<T extends number> =
-    `${T}` extends `-${infer U extends number}` ? U : T
+  export type Abs<T extends number> = `${T}` extends `-${infer U extends
+    number}`
+    ? U
+    : T
 
   export type GetPositiveIndex<
     T extends string,

--- a/src/native/char-at.test.ts
+++ b/src/native/char-at.test.ts
@@ -1,7 +1,12 @@
 import { type CharAt, charAt } from './char-at.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<CharAt<'some nice string', 5>, 'n'>>
+  type test1 = Expect<Equal<CharAt<'some nice string', 5>, 'n'>>
+  type test2 = Expect<Equal<CharAt<string, 5>, string>>
+  type test3 = Expect<Equal<CharAt<'some nice string', number>, string>>
+
+  // TODO: index greater than Length<T>
+  // type test4 = Expect<Equal<CharAt<'some nice string', 100>, ''>>
 }
 
 describe('charAt', () => {

--- a/src/native/char-at.ts
+++ b/src/native/char-at.ts
@@ -5,7 +5,11 @@ import type { Split } from './split.js'
  * T: The string to get the character from.
  * index: The index of the character.
  */
-export type CharAt<T extends string, index extends number> = Split<T>[index]
+export type CharAt<T extends string, index extends number> = string extends T
+  ? string
+  : number extends index
+  ? string
+  : Split<T>[index]
 /**
  * A strongly-typed version of `String.prototype.charAt`.
  * @param str the string to get the character from.
@@ -17,5 +21,5 @@ export function charAt<T extends string, I extends number>(
   str: T,
   index: I,
 ): CharAt<T, I> {
-  return str.charAt(index)
+  return str.charAt(index) as CharAt<T, I>
 }

--- a/src/native/concat.test.ts
+++ b/src/native/concat.test.ts
@@ -1,9 +1,11 @@
 import { type Concat, concat } from './concat.js'
 
 namespace TypeTests {
-  type test = Expect<
+  type test1 = Expect<Equal<Concat<['a', 'bc', 'def']>, 'abcdef'>>
+  type test2 = Expect<
     Equal<Concat<['a', 'bc', 'def'] | ['1', '23', '456']>, 'abcdef' | '123456'>
   >
+  type test3 = Expect<Equal<Concat<string[]>, string>>
 }
 
 describe('concat', () => {

--- a/src/native/ends-with.test.ts
+++ b/src/native/ends-with.test.ts
@@ -1,7 +1,9 @@
 import { type EndsWith, endsWith } from './ends-with.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<EndsWith<'abc', 'c'>, true>>
+  type test1 = Expect<Equal<EndsWith<'abc', 'c'>, true>>
+  type test2 = Expect<Equal<EndsWith<string, 'c'>, boolean>>
+  type test3 = Expect<Equal<EndsWith<'abc', string>, boolean>>
 }
 
 describe('endsWith', () => {

--- a/src/native/ends-with.ts
+++ b/src/native/ends-with.ts
@@ -12,7 +12,9 @@ export type EndsWith<
   T extends string,
   S extends string,
   P extends number = Length<T>,
-> = Math.IsNegative<P> extends false
+> = string extends T | S
+  ? boolean
+  : Math.IsNegative<P> extends false
   ? P extends Length<T>
     ? S extends Slice<T, Math.Subtract<Length<T>, Length<S>>, Length<T>>
       ? true

--- a/src/native/includes.test.ts
+++ b/src/native/includes.test.ts
@@ -1,7 +1,9 @@
 import { type Includes, includes } from './includes.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<Includes<'abcde', 'bcd'>, true>>
+  type test1 = Expect<Equal<Includes<'abcde', 'bcd'>, true>>
+  type test2 = Expect<Equal<Includes<string, 'bcd'>, boolean>>
+  type test3 = Expect<Equal<Includes<'abcde', string>, boolean>>
 }
 
 describe('includes', () => {

--- a/src/native/includes.ts
+++ b/src/native/includes.ts
@@ -11,7 +11,9 @@ export type Includes<
   T extends string,
   S extends string,
   P extends number = 0,
-> = Math.IsNegative<P> extends false
+> = string extends T | S
+  ? boolean
+  : Math.IsNegative<P> extends false
   ? P extends 0
     ? T extends `${string}${S}${string}`
       ? true

--- a/src/native/join.test.ts
+++ b/src/native/join.test.ts
@@ -1,9 +1,11 @@
 import { type Join, join } from './join.js'
 
 namespace TypeTests {
-  type test = Expect<
+  type test1 = Expect<
     Equal<Join<['some', 'nice', 'string'], ' '>, 'some nice string'>
   >
+  type test2 = Expect<Equal<Join<string[], ' '>, string>>
+  type test3 = Expect<Equal<Join<['some', 'nice', 'string'], string>, string>>
 }
 
 describe('join', () => {

--- a/src/native/join.ts
+++ b/src/native/join.ts
@@ -7,7 +7,9 @@ export type Join<
   T extends readonly string[],
   delimiter extends string = '',
 > = string[] extends T
-  ? string // Avoid spending resources on a wide type
+  ? string
+  : string extends delimiter
+  ? string
   : T extends readonly [
       infer first extends string,
       ...infer rest extends string[],

--- a/src/native/length.test.ts
+++ b/src/native/length.test.ts
@@ -1,7 +1,8 @@
 import { type Length, length } from './length.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<Length<'some nice string'>, 16>>
+  type test1 = Expect<Equal<Length<'some nice string'>, 16>>
+  type test2 = Expect<Equal<Length<string>, number>>
 }
 
 describe('length', () => {

--- a/src/native/length.ts
+++ b/src/native/length.ts
@@ -3,7 +3,9 @@ import type { Split } from './split.js'
 /**
  * Gets the length of a string.
  */
-export type Length<T extends string> = Split<T>['length']
+export type Length<T extends string> = string extends T
+  ? number
+  : Split<T>['length']
 /**
  * A strongly-typed version of `String.prototype.length`.
  * @param str the string to get the length from.

--- a/src/native/pad-end.test.ts
+++ b/src/native/pad-end.test.ts
@@ -1,4 +1,11 @@
-import { padEnd } from './pad-end.js'
+import { type PadEnd, padEnd } from './pad-end.js'
+
+namespace TypeTests {
+  type test1 = Expect<Equal<PadEnd<'hello', 10, ' '>, 'hello     '>>
+  type test2 = Expect<Equal<PadEnd<string, 10, ' '>, string>>
+  type test3 = Expect<Equal<PadEnd<'hello', number, ' '>, string>>
+  type test4 = Expect<Equal<PadEnd<'hello', 10, string>, string>>
+}
 
 describe('padEnd', () => {
   test('should pad a string at the end', () => {

--- a/src/native/pad-end.ts
+++ b/src/native/pad-end.ts
@@ -13,7 +13,11 @@ export type PadEnd<
   T extends string,
   times extends number = 0,
   pad extends string = ' ',
-> = Math.IsNegative<times> extends false
+> = string extends T | pad
+  ? string
+  : number extends times
+  ? string
+  : Math.IsNegative<times> extends false
   ? Math.Subtract<times, Length<T>> extends infer missing extends number
     ? `${T}${Slice<Repeat<pad, missing>, 0, missing>}`
     : never

--- a/src/native/pad-start.test.ts
+++ b/src/native/pad-start.test.ts
@@ -1,4 +1,11 @@
-import { padStart } from './pad-start.js'
+import { type PadStart, padStart } from './pad-start.js'
+
+namespace TypeTests {
+  type test1 = Expect<Equal<PadStart<'hello', 10, ' '>, '     hello'>>
+  type test2 = Expect<Equal<PadStart<string, 10, ' '>, string>>
+  type test3 = Expect<Equal<PadStart<'hello', number, ' '>, string>>
+  type test4 = Expect<Equal<PadStart<'hello', 10, string>, string>>
+}
 
 describe('padStart', () => {
   test('should pad a string at the start', () => {

--- a/src/native/pad-start.ts
+++ b/src/native/pad-start.ts
@@ -13,7 +13,11 @@ export type PadStart<
   T extends string,
   times extends number = 0,
   pad extends string = ' ',
-> = Math.IsNegative<times> extends false
+> = string extends T | pad
+  ? string
+  : number extends times
+  ? string
+  : Math.IsNegative<times> extends false
   ? Math.Subtract<times, Length<T>> extends infer missing extends number
     ? `${Slice<Repeat<pad, missing>, 0, missing>}${T}`
     : never

--- a/src/native/repeat.test.ts
+++ b/src/native/repeat.test.ts
@@ -1,5 +1,10 @@
-import type { Repeat } from './repeat.js'
-import { repeat } from './repeat.js'
+import { type Repeat, repeat } from './repeat.js'
+
+namespace TypeTests {
+  type test1 = Expect<Equal<Repeat<' ', 3>, '   '>>
+  type test2 = Expect<Equal<Repeat<string, 3>, string>>
+  type test3 = Expect<Equal<Repeat<' ', number>, string>>
+}
 
 describe('repeat', () => {
   test('should repeat the string by a given number of times', () => {

--- a/src/native/repeat.ts
+++ b/src/native/repeat.ts
@@ -7,7 +7,14 @@ import type { TupleOf } from '../internal/internals.js'
  * T: The string to repeat.
  * N: The number of times to repeat.
  */
-export type Repeat<T extends string, times extends number = 0> = times extends 0
+export type Repeat<
+  T extends string,
+  times extends number = 0,
+> = string extends T
+  ? string
+  : number extends times
+  ? string
+  : times extends 0
   ? ''
   : Math.IsNegative<times> extends false
   ? Join<TupleOf<times, T>>

--- a/src/native/replace-all.test.ts
+++ b/src/native/replace-all.test.ts
@@ -2,8 +2,18 @@
 import { type ReplaceAll, replaceAll } from './replace-all.js'
 
 namespace TypeTests {
-  type test = Expect<
+  type test1 = Expect<
     Equal<ReplaceAll<'some nice string', ' ', '-'>, 'some-nice-string'>
+  >
+  type test2 = Expect<
+    Equal<ReplaceAll<'some nice string', RegExp, '-'>, string>
+  >
+  type test3 = Expect<Equal<ReplaceAll<string, ' ', '-'>, string>>
+  type test4 = Expect<
+    Equal<ReplaceAll<'some nice string', string, '-'>, string>
+  >
+  type test5 = Expect<
+    Equal<ReplaceAll<'some nice string', ' ', string>, string>
   >
 }
 

--- a/src/native/replace-all.ts
+++ b/src/native/replace-all.ts
@@ -9,7 +9,9 @@ export type ReplaceAll<
   lookup extends string | RegExp,
   replacement extends string = '',
 > = lookup extends string
-  ? sentence extends `${infer rest}${lookup}${infer rest2}`
+  ? string extends lookup | sentence | replacement
+    ? string
+    : sentence extends `${infer rest}${lookup}${infer rest2}`
     ? `${rest}${replacement}${ReplaceAll<rest2, lookup, replacement>}`
     : sentence
   : string

--- a/src/native/replace.test.ts
+++ b/src/native/replace.test.ts
@@ -1,9 +1,13 @@
 import { type Replace, replace } from './replace.js'
 
 namespace TypeTests {
-  type test = Expect<
+  type test1 = Expect<
     Equal<Replace<'some nice string', ' ', '-'>, 'some-nice string'>
   >
+  type test2 = Expect<Equal<Replace<'some nice string', RegExp, '-'>, string>>
+  type test3 = Expect<Equal<Replace<string, ' ', '-'>, string>>
+  type test4 = Expect<Equal<Replace<'some nice string', string, '-'>, string>>
+  type test5 = Expect<Equal<Replace<'some nice string', ' ', string>, string>>
 }
 
 describe('replace', () => {

--- a/src/native/replace.ts
+++ b/src/native/replace.ts
@@ -9,10 +9,12 @@ export type Replace<
   lookup extends string | RegExp,
   replacement extends string = '',
 > = lookup extends string
-  ? sentence extends `${infer rest}${lookup}${infer rest2}`
+  ? string extends lookup | sentence | replacement
+    ? string
+    : sentence extends `${infer rest}${lookup}${infer rest2}`
     ? `${rest}${replacement}${rest2}`
     : sentence
-  : string
+  : string // Regex used, can't preserve literal
 /**
  * A strongly-typed version of `String.prototype.replace`.
  * @param sentence the sentence to replace.

--- a/src/native/slice.test.ts
+++ b/src/native/slice.test.ts
@@ -1,7 +1,11 @@
 import { type Slice, slice } from './slice.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<Slice<'some nice string', 5>, 'nice string'>>
+  type test1 = Expect<Equal<Slice<'some nice string', 5>, 'nice string'>>
+  type test2 = Expect<Equal<Slice<'some nice string', 5, 9>, 'nice'>>
+  type test3 = Expect<Equal<Slice<string, 5, 9>, string>>
+  type test4 = Expect<Equal<Slice<'some nice string', number, 9>, string>>
+  type test5 = Expect<Equal<Slice<'some nice string', 5, number>, string>>
 }
 
 describe('slice', () => {

--- a/src/native/slice.ts
+++ b/src/native/slice.ts
@@ -11,7 +11,11 @@ export type Slice<
   T extends string,
   startIndex extends number = 0,
   endIndex extends number = Length<T>,
-> = T extends `${infer head}${infer rest}`
+> = string extends T
+  ? string
+  : number extends startIndex | endIndex
+  ? string
+  : T extends `${infer head}${infer rest}`
   ? startIndex extends 0
     ? endIndex extends 0
       ? ''

--- a/src/native/split.test.ts
+++ b/src/native/split.test.ts
@@ -1,9 +1,11 @@
 import { type Split, split } from './split.js'
 
 namespace TypeTests {
-  type test = Expect<
+  type test1 = Expect<
     Equal<Split<'some nice string', ' '>, ['some', 'nice', 'string']>
   >
+  type test2 = Expect<Equal<Split<string, ' '>, string[]>>
+  type test3 = Expect<Equal<Split<'some nice string', string>, string[]>>
 }
 
 describe('split', () => {

--- a/src/native/split.ts
+++ b/src/native/split.ts
@@ -4,9 +4,11 @@
  * delimiter: The delimiter.
  */
 export type Split<
-  T,
+  T extends string,
   delimiter extends string = '',
-> = T extends `${infer first}${delimiter}${infer rest}`
+> = string extends T | delimiter
+  ? string[]
+  : T extends `${infer first}${delimiter}${infer rest}`
   ? [first, ...Split<rest, delimiter>]
   : T extends ''
   ? []

--- a/src/native/starts-with.test.ts
+++ b/src/native/starts-with.test.ts
@@ -1,7 +1,11 @@
 import { type StartsWith, startsWith } from './starts-with.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<StartsWith<'abc', 'a'>, true>>
+  type test1 = Expect<Equal<StartsWith<'abc', 'a'>, true>>
+  type test2 = Expect<Equal<StartsWith<'abc', 'b', 1>, true>>
+  type test3 = Expect<Equal<StartsWith<string, 'a'>, boolean>>
+  type test4 = Expect<Equal<StartsWith<'abc', string>, boolean>>
+  type test5 = Expect<Equal<StartsWith<'abc', 'a', number>, boolean>>
 }
 
 describe('startsWith', () => {

--- a/src/native/starts-with.ts
+++ b/src/native/starts-with.ts
@@ -11,7 +11,11 @@ export type StartsWith<
   T extends string,
   S extends string,
   P extends number = 0,
-> = Math.IsNegative<P> extends false
+> = string extends T | S
+  ? boolean
+  : number extends P
+  ? boolean
+  : Math.IsNegative<P> extends false
   ? P extends 0
     ? T extends `${S}${string}`
       ? true

--- a/src/native/trim-end.test.ts
+++ b/src/native/trim-end.test.ts
@@ -1,7 +1,8 @@
 import { type TrimEnd, trimEnd } from './trim-end.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<TrimEnd<' some nice string '>, ' some nice string'>>
+  type test1 = Expect<Equal<TrimEnd<' some nice string '>, ' some nice string'>>
+  type test2 = Expect<Equal<TrimEnd<string>, string>>
 }
 
 describe('trimEnd', () => {

--- a/src/native/trim-end.ts
+++ b/src/native/trim-end.ts
@@ -2,7 +2,9 @@
  * Trims all whitespaces at the end of a string.
  * T: The string to trim.
  */
-export type TrimEnd<T extends string> = T extends `${infer rest} `
+export type TrimEnd<T extends string> = string extends T
+  ? string
+  : T extends `${infer rest} `
   ? TrimEnd<rest>
   : T
 /**

--- a/src/native/trim-start.test.ts
+++ b/src/native/trim-start.test.ts
@@ -1,9 +1,10 @@
 import { type TrimStart, trimStart } from './trim-start.js'
 
 namespace TypeTests {
-  type test = Expect<
+  type test1 = Expect<
     Equal<TrimStart<' some nice string '>, 'some nice string '>
   >
+  type test2 = Expect<Equal<TrimStart<string>, string>>
 }
 
 describe('trimStart', () => {

--- a/src/native/trim-start.ts
+++ b/src/native/trim-start.ts
@@ -2,7 +2,9 @@
  * Trims all whitespaces at the start of a string.
  * T: The string to trim.
  */
-export type TrimStart<T extends string> = T extends ` ${infer rest}`
+export type TrimStart<T extends string> = string extends T
+  ? string
+  : T extends ` ${infer rest}`
   ? TrimStart<rest>
   : T
 /**

--- a/src/native/trim.test.ts
+++ b/src/native/trim.test.ts
@@ -1,7 +1,8 @@
 import { type Trim, trim } from './trim.js'
 
 namespace TypeTests {
-  type test = Expect<Equal<Trim<' some nice string '>, 'some nice string'>>
+  type test1 = Expect<Equal<Trim<' some nice string '>, 'some nice string'>>
+  type test2 = Expect<Equal<Trim<string>, string>>
 }
 
 describe('trim', () => {

--- a/src/utils/characters/letters.test.ts
+++ b/src/utils/characters/letters.test.ts
@@ -1,20 +1,23 @@
 import type { IsLower, IsUpper, IsLetter } from './letters.js'
 
 namespace TypeChecks {
-  type test1 = Expect<Equal<IsLower<'1'>, false>>
-  type test2 = Expect<Equal<IsLower<'a'>, true>>
-  type test3 = Expect<Equal<IsLower<'A'>, false>>
-  type test4 = Expect<Equal<IsLower<'$'>, false>>
+  type testIsLower1 = Expect<Equal<IsLower<'1'>, false>>
+  type testIsLower2 = Expect<Equal<IsLower<'a'>, true>>
+  type testIsLower3 = Expect<Equal<IsLower<'A'>, false>>
+  type testIsLower4 = Expect<Equal<IsLower<'$'>, false>>
+  type testIsLower5 = Expect<Equal<IsLower<string>, boolean>>
 
-  type test5 = Expect<Equal<IsUpper<'1'>, false>>
-  type test6 = Expect<Equal<IsUpper<'a'>, false>>
-  type test7 = Expect<Equal<IsUpper<'A'>, true>>
-  type test8 = Expect<Equal<IsUpper<'$'>, false>>
+  type testIsUpper1 = Expect<Equal<IsUpper<'1'>, false>>
+  type testIsUpper2 = Expect<Equal<IsUpper<'a'>, false>>
+  type testIsUpper3 = Expect<Equal<IsUpper<'A'>, true>>
+  type testIsUpper4 = Expect<Equal<IsUpper<'$'>, false>>
+  type testIsUpper5 = Expect<Equal<IsUpper<string>, boolean>>
 
-  type test9 = Expect<Equal<IsLetter<'1'>, false>>
-  type test10 = Expect<Equal<IsLetter<'a'>, true>>
-  type test11 = Expect<Equal<IsLetter<'A'>, true>>
-  type test12 = Expect<Equal<IsLetter<'$'>, false>>
+  type testIsLetter1 = Expect<Equal<IsLetter<'1'>, false>>
+  type testIsLetter2 = Expect<Equal<IsLetter<'a'>, true>>
+  type testIsLetter3 = Expect<Equal<IsLetter<'A'>, true>>
+  type testIsLetter4 = Expect<Equal<IsLetter<'$'>, false>>
+  type testIsLetter5 = Expect<Equal<IsLetter<string>, boolean>>
 }
 
 test('dummy test', () => expect(true).toBe(true))

--- a/src/utils/characters/letters.ts
+++ b/src/utils/characters/letters.ts
@@ -6,17 +6,27 @@ type LowerChars = Lowercase<UpperChars>
 /**
  * Checks if the given character is an upper case letter.
  */
-export type IsUpper<T extends string> = T extends UpperChars ? true : false
+export type IsUpper<T extends string> = string extends T
+  ? boolean
+  : T extends UpperChars
+  ? true
+  : false
 
 /**
  * Checks if the given character is a lower case letter.
  */
-export type IsLower<T extends string> = T extends LowerChars ? true : false
+export type IsLower<T extends string> = string extends T
+  ? boolean
+  : T extends LowerChars
+  ? true
+  : false
 
 /**
  * Checks if the given character is a letter.
  */
-export type IsLetter<T extends string> = IsUpper<T> extends true
+export type IsLetter<T extends string> = string extends T
+  ? boolean
+  : IsUpper<T> extends true
   ? true
   : IsLower<T> extends true
   ? true

--- a/src/utils/characters/numbers.test.ts
+++ b/src/utils/characters/numbers.test.ts
@@ -5,6 +5,7 @@ namespace TypeChecks {
   type test2 = Expect<Equal<IsDigit<'a'>, false>>
   type test3 = Expect<Equal<IsDigit<'A'>, false>>
   type test4 = Expect<Equal<IsDigit<'$'>, false>>
+  type test5 = Expect<Equal<IsDigit<string>, boolean>>
 }
 
 test('dummy test', () => expect(true).toBe(true))

--- a/src/utils/characters/numbers.ts
+++ b/src/utils/characters/numbers.ts
@@ -3,4 +3,8 @@ export type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
 /**
  * Checks if the given character is a number.
  */
-export type IsDigit<T extends string> = T extends Digit ? true : false
+export type IsDigit<T extends string> = string extends T
+  ? boolean
+  : T extends Digit
+  ? true
+  : false

--- a/src/utils/characters/separators.test.ts
+++ b/src/utils/characters/separators.test.ts
@@ -11,6 +11,7 @@ namespace TypeChecks {
   type test7 = Expect<Equal<IsSeparator<'/'>, true>>
   type test8 = Expect<Equal<IsSeparator<'_'>, true>>
   type test9 = Expect<Equal<IsSeparator<'.'>, true>>
+  type test10 = Expect<Equal<IsSeparator<string>, boolean>>
 }
 
 describe('SEPARATOR_REGEX', () => {

--- a/src/utils/characters/separators.ts
+++ b/src/utils/characters/separators.ts
@@ -30,4 +30,8 @@ export type Separator = (typeof SEPARATORS)[number]
  * Checks if the given character is a separator.
  * E.g. space, underscore, dash, dot, slash.
  */
-export type IsSeparator<T extends string> = T extends Separator ? true : false
+export type IsSeparator<T extends string> = string extends T
+  ? boolean
+  : T extends Separator
+  ? true
+  : false

--- a/src/utils/characters/special.test.ts
+++ b/src/utils/characters/special.test.ts
@@ -8,5 +8,6 @@ namespace TypeChecks {
   type test5 = Expect<Equal<Subject.IsSpecial<' '>, false>>
   type test6 = Expect<Equal<Subject.IsSpecial<'*'>, true>>
   type test7 = Expect<Equal<Subject.IsSpecial<'_'>, false>>
+  type test8 = Expect<Equal<Subject.IsSpecial<string>, boolean>>
 }
 test('dummy test', () => expect(true).toBe(true))

--- a/src/utils/characters/special.ts
+++ b/src/utils/characters/special.ts
@@ -6,7 +6,9 @@ import type { IsDigit } from './numbers.js'
  * Checks if the given character is a special character.
  * E.g. not a letter, number, or separator.
  */
-export type IsSpecial<T extends string> = IsLetter<T> extends true
+export type IsSpecial<T extends string> = string extends T
+  ? boolean
+  : IsLetter<T> extends true
   ? false
   : IsDigit<T> extends true
   ? false

--- a/src/utils/reverse.test.ts
+++ b/src/utils/reverse.test.ts
@@ -6,6 +6,7 @@ namespace ReverseTests {
   type test3 = Expect<
     Equal<Reverse<'I love TypeScript!'>, '!tpircSepyT evol I'>
   >
+  type test4 = Expect<Equal<Reverse<string>, string>>
 }
 
 describe('reverse', () => {

--- a/src/utils/truncate.test.ts
+++ b/src/utils/truncate.test.ts
@@ -7,6 +7,9 @@ namespace TruncateTests {
   type test4 = Expect<Equal<Truncate<'Hello, world', 9, '[...]'>, 'Hell[...]'>>
   type test5 = Expect<Equal<Truncate<'Hello, world', -1>, '...'>>
   type test6 = Expect<Equal<Truncate<'Hello, world', 0, '[...]'>, '[...]'>>
+  type test7 = Expect<Equal<Truncate<string, 0, '[...]'>, string>>
+  type test8 = Expect<Equal<Truncate<'Hello, world', number, '[...]'>, string>>
+  type test9 = Expect<Equal<Truncate<'Hello, world', 0, string>, string>>
 }
 
 describe('truncate', () => {

--- a/src/utils/truncate.ts
+++ b/src/utils/truncate.ts
@@ -13,7 +13,11 @@ export type Truncate<
   T extends string,
   Size extends number,
   Omission extends string = '...',
-> = Math.IsNegative<Size> extends true
+> = string extends T | Omission
+  ? string
+  : number extends Size
+  ? string
+  : Math.IsNegative<Size> extends true
   ? Omission
   : Math.Subtract<Length<T>, Size> extends 0
   ? T
@@ -32,8 +36,11 @@ export function truncate<
   T extends string,
   S extends number,
   P extends string = '...',
->(sentence: T, length: S, omission = '...' as P): Truncate<T, S, P> {
+>(sentence: T, length: S, omission = '...' as P) {
   if (length < 0) return omission as Truncate<T, S, P>
   if (sentence.length <= length) return sentence as Truncate<T, S, P>
-  return join([sentence.slice(0, length - omission.length), omission])
+  return join([
+    sentence.slice(0, length - omission.length),
+    omission,
+  ]) as Truncate<T, S, P>
 }

--- a/src/utils/words.test.ts
+++ b/src/utils/words.test.ts
@@ -20,6 +20,9 @@ namespace WordsTests {
       ]
     >
   >
+  type test2 = Expect<Equal<Words<string>, string[]>>
+  type test3 = Expect<Equal<Words<'abc def', string>, string[]>>
+  type test4 = Expect<Equal<Words<'abc def', ' ', string>, string[]>>
 }
 
 type Mutable<Type> = {

--- a/src/utils/words.ts
+++ b/src/utils/words.ts
@@ -15,7 +15,7 @@ export type Words<
   sentence extends string,
   word extends string = '',
   prev extends string = '',
-> = string extends sentence
+> = string extends sentence | word | prev
   ? string[] // Avoid spending resources on a wide type
   : sentence extends `${infer curr}${infer rest}`
   ? IsSeparator<curr> extends true


### PR DESCRIPTION
Partial of https://github.com/gustavoguichard/string-ts/pull/80

Handle non-literal types better

```ts
Length<"abc"> // 3
Length<string> // 1 (Oops)
Length<`abc${string}`> // 4 (Oops)
```