### PR TITLE
fix: words should drop apostrophes

### DIFF
--- a/src/internal/fixtures.ts
+++ b/src/internal/fixtures.ts
@@ -4,4 +4,7 @@ export const SEPARATORS_TEXT =
 export const WEIRD_TEXT =
   ' someWeird-cased$*String1986Foo [Bar] W_FOR_WUMBO...' as const
 
-export type WeirdTextUnion = typeof WEIRD_TEXT | 'dont.distribute unions'
+export type WeirdTextUnion =
+  | typeof WEIRD_TEXT
+  | "where's the leak ma'am"
+  | 'dont.distribute unions'

--- a/src/native/replace-all.ts
+++ b/src/native/replace-all.ts
@@ -1,4 +1,4 @@
-import type { All, IsStringLiteral } from '../internal/literals.js'
+import type { IsStringLiteral } from '../internal/literals.js'
 
 /**
  * Replaces all the occurrences of a string with another string.

--- a/src/utils/characters/apostrophe.ts
+++ b/src/utils/characters/apostrophe.ts
@@ -1,0 +1,21 @@
+import type { IsStringLiteral } from '../../internal/literals.js'
+import { replaceAll, type ReplaceAll } from '../../native/replace-all.js'
+
+type Apostrophe = "'"
+
+/**
+ * Checks if the given character is an apostrophe
+ */
+export type IsApostrophe<T extends string> = IsStringLiteral<T> extends true
+  ? T extends Apostrophe
+    ? true
+    : false
+  : boolean
+
+export type RemoveApostrophe<T extends string> = ReplaceAll<T, "'", ''>
+
+export function removeApostrophe<T extends string>(
+  str: T,
+): RemoveApostrophe<T> {
+  return replaceAll(str, "'", '')
+}

--- a/src/utils/characters/special.ts
+++ b/src/utils/characters/special.ts
@@ -1,6 +1,7 @@
 import type { IsSeparator } from './separators.js'
 import type { IsLetter } from './letters.js'
 import type { IsDigit } from './numbers.js'
+import type { IsApostrophe } from './apostrophe.js'
 import type { IsStringLiteral } from '../../internal/literals.js'
 
 /**
@@ -11,8 +12,10 @@ export type IsSpecial<T extends string> = IsStringLiteral<T> extends true
   ? IsLetter<T> extends true
     ? false
     : IsDigit<T> extends true
-    ? false
-    : IsSeparator<T> extends true
-    ? false
-    : true
+      ? false
+      : IsSeparator<T> extends true
+        ? false
+        : IsApostrophe<T> extends true
+          ? false
+          : true
   : boolean

--- a/src/utils/word-case/camel-case.test.ts
+++ b/src/utils/word-case/camel-case.test.ts
@@ -9,7 +9,9 @@ namespace TypeTransforms {
   type test = Expect<
     Equal<
       CamelCase<WeirdTextUnion>,
-      'someWeirdCased$*String1986FooBarWForWumbo' | 'dontDistributeUnions'
+      | 'someWeirdCased$*String1986FooBarWForWumbo'
+      | 'wheresTheLeakMaam'
+      | 'dontDistributeUnions'
     >
   >
 }

--- a/src/utils/word-case/camel-case.ts
+++ b/src/utils/word-case/camel-case.ts
@@ -1,10 +1,16 @@
 import { type PascalCase, pascalCase } from './pascal-case.js'
 import { uncapitalize } from './uncapitalize.js'
+import {
+  removeApostrophe,
+  type RemoveApostrophe,
+} from '../characters/apostrophe.js'
 
 /**
  * Transforms a string to camelCase.
  */
-export type CamelCase<T extends string> = Uncapitalize<PascalCase<T>>
+export type CamelCase<T extends string> = Uncapitalize<
+  PascalCase<RemoveApostrophe<T>>
+>
 
 /**
  * A strongly typed version of `camelCase` that works in both runtime and type level.
@@ -13,7 +19,7 @@ export type CamelCase<T extends string> = Uncapitalize<PascalCase<T>>
  * @example camelCase('hello world') // 'helloWorld'
  */
 export function camelCase<T extends string>(str: T): CamelCase<T> {
-  return uncapitalize(pascalCase(str))
+  return uncapitalize(pascalCase(removeApostrophe(str)))
 }
 
 /**

--- a/src/utils/word-case/constant-case.test.ts
+++ b/src/utils/word-case/constant-case.test.ts
@@ -9,6 +9,7 @@ namespace TypeTransforms {
     Equal<
       ConstantCase<WeirdTextUnion>,
       | 'SOME_WEIRD_CASED_$*_STRING_1986_FOO_BAR_W_FOR_WUMBO'
+      | 'WHERES_THE_LEAK_MAAM'
       | 'DONT_DISTRIBUTE_UNIONS'
     >
   >

--- a/src/utils/word-case/constant-case.ts
+++ b/src/utils/word-case/constant-case.ts
@@ -1,10 +1,16 @@
 import { type DelimiterCase, delimiterCase } from './delimiter-case.js'
 import { toUpperCase } from '../../native/to-upper-case.js'
+import {
+  removeApostrophe,
+  type RemoveApostrophe,
+} from '../characters/apostrophe.js'
 
 /**
  * Transforms a string to CONSTANT_CASE.
  */
-export type ConstantCase<T extends string> = Uppercase<DelimiterCase<T, '_'>>
+export type ConstantCase<T extends string> = Uppercase<
+  DelimiterCase<RemoveApostrophe<T>, '_'>
+>
 /**
  * A strongly typed version of `constantCase` that works in both runtime and type level.
  * @param str the string to convert to constant case.
@@ -12,7 +18,7 @@ export type ConstantCase<T extends string> = Uppercase<DelimiterCase<T, '_'>>
  * @example constantCase('hello world') // 'HELLO_WORLD'
  */
 export function constantCase<T extends string>(str: T): ConstantCase<T> {
-  return toUpperCase(delimiterCase(str, '_'))
+  return toUpperCase(delimiterCase(removeApostrophe(str), '_'))
 }
 
 /**

--- a/src/utils/word-case/delimiter-case.test.ts
+++ b/src/utils/word-case/delimiter-case.test.ts
@@ -10,6 +10,7 @@ namespace TypeTransforms {
     Equal<
       DelimiterCase<WeirdTextUnion, '%'>,
       | 'some%Weird%cased%$*%String%1986%Foo%Bar%W%FOR%WUMBO'
+      | 'wheres%the%leak%maam'
       | 'dont%distribute%unions'
     >
   >

--- a/src/utils/word-case/delimiter-case.ts
+++ b/src/utils/word-case/delimiter-case.ts
@@ -1,11 +1,15 @@
 import { type Join, join } from '../../native/join.js'
 import { type Words, words } from '../words.js'
+import {
+  removeApostrophe,
+  type RemoveApostrophe,
+} from '../characters/apostrophe.js'
 
 /**
  * Transforms a string with the specified separator (delimiter).
  */
 export type DelimiterCase<T extends string, D extends string> = Join<
-  Words<T>,
+  Words<RemoveApostrophe<T>>,
   D
 >
 /**
@@ -19,7 +23,7 @@ export function delimiterCase<T extends string, D extends string>(
   str: T,
   delimiter: D,
 ): DelimiterCase<T, D> {
-  return join(words(str), delimiter)
+  return join(words(removeApostrophe(str)), delimiter)
 }
 
 /**

--- a/src/utils/word-case/kebab-case.test.ts
+++ b/src/utils/word-case/kebab-case.test.ts
@@ -10,6 +10,7 @@ namespace TypeTransforms {
     Equal<
       KebabCase<WeirdTextUnion>,
       | 'some-weird-cased-$*-string-1986-foo-bar-w-for-wumbo'
+      | 'wheres-the-leak-maam'
       | 'dont-distribute-unions'
     >
   >

--- a/src/utils/word-case/kebab-case.ts
+++ b/src/utils/word-case/kebab-case.ts
@@ -1,10 +1,16 @@
 import { type DelimiterCase, delimiterCase } from './delimiter-case.js'
 import { toLowerCase } from '../../native/to-lower-case.js'
+import {
+  removeApostrophe,
+  type RemoveApostrophe,
+} from '../characters/apostrophe.js'
 
 /**
  * Transforms a string to kebab-case.
  */
-export type KebabCase<T extends string> = Lowercase<DelimiterCase<T, '-'>>
+export type KebabCase<T extends string> = Lowercase<
+  DelimiterCase<RemoveApostrophe<T>, '-'>
+>
 /**
  * A strongly typed version of `kebabCase` that works in both runtime and type level.
  * @param str the string to convert to kebab case.
@@ -12,7 +18,7 @@ export type KebabCase<T extends string> = Lowercase<DelimiterCase<T, '-'>>
  * @example kebabCase('hello world') // 'hello-world'
  */
 export function kebabCase<T extends string>(str: T): KebabCase<T> {
-  return toLowerCase(delimiterCase(str, '-'))
+  return toLowerCase(delimiterCase(removeApostrophe(str), '-'))
 }
 
 /**

--- a/src/utils/word-case/pascal-case.test.ts
+++ b/src/utils/word-case/pascal-case.test.ts
@@ -9,7 +9,9 @@ namespace TypeTransforms {
   type test = Expect<
     Equal<
       PascalCase<WeirdTextUnion>,
-      'SomeWeirdCased$*String1986FooBarWForWumbo' | 'DontDistributeUnions'
+      | 'SomeWeirdCased$*String1986FooBarWForWumbo'
+      | 'WheresTheLeakMaam'
+      | 'DontDistributeUnions'
     >
   >
 }

--- a/src/utils/word-case/pascal-case.ts
+++ b/src/utils/word-case/pascal-case.ts
@@ -1,11 +1,17 @@
 import { type PascalCaseAll, pascalCaseAll } from '../../internal/internals.js'
 import { type Join, join } from '../../native/join.js'
 import { type Words, words } from '../words.js'
+import {
+  removeApostrophe,
+  type RemoveApostrophe,
+} from '../characters/apostrophe.js'
 
 /**
  * Transforms a string to PascalCase.
  */
-export type PascalCase<T extends string> = Join<PascalCaseAll<Words<T>>>
+export type PascalCase<T extends string> = Join<
+  PascalCaseAll<Words<RemoveApostrophe<T>>>
+>
 /**
  * A strongly typed version of `pascalCase` that works in both runtime and type level.
  * @param str the string to convert to pascal case.
@@ -13,7 +19,7 @@ export type PascalCase<T extends string> = Join<PascalCaseAll<Words<T>>>
  * @example pascalCase('hello world') // 'HelloWorld'
  */
 export function pascalCase<T extends string>(str: T): PascalCase<T> {
-  return join(pascalCaseAll(words(str)))
+  return join(pascalCaseAll(words(removeApostrophe(str))))
 }
 
 /**

--- a/src/utils/word-case/snake-case.test.ts
+++ b/src/utils/word-case/snake-case.test.ts
@@ -10,9 +10,11 @@ namespace TypeTransforms {
     Equal<
       SnakeCase<WeirdTextUnion>,
       | 'some_weird_cased_$*_string_1986_foo_bar_w_for_wumbo'
+      | 'wheres_the_leak_maam'
       | 'dont_distribute_unions'
     >
   >
+  type test2 = Expect<Equal<SnakeCase<"don'tGo">, 'dont_go'>>
 }
 
 describe('snakeCase', () => {

--- a/src/utils/word-case/snake-case.test.ts
+++ b/src/utils/word-case/snake-case.test.ts
@@ -14,7 +14,6 @@ namespace TypeTransforms {
       | 'dont_distribute_unions'
     >
   >
-  type test2 = Expect<Equal<SnakeCase<"don'tGo">, 'dont_go'>>
 }
 
 describe('snakeCase', () => {

--- a/src/utils/word-case/snake-case.ts
+++ b/src/utils/word-case/snake-case.ts
@@ -1,10 +1,16 @@
 import { type DelimiterCase, delimiterCase } from './delimiter-case.js'
 import { toLowerCase } from '../../native/to-lower-case.js'
+import {
+  removeApostrophe,
+  type RemoveApostrophe,
+} from '../characters/apostrophe.js'
 
 /**
  * Transforms a string to snake_case.
  */
-export type SnakeCase<T extends string> = Lowercase<DelimiterCase<T, '_'>>
+export type SnakeCase<T extends string> = Lowercase<
+  DelimiterCase<RemoveApostrophe<T>, '_'>
+>
 /**
  * A strongly typed version of `snakeCase` that works in both runtime and type level.
  * @param str the string to convert to snake case.
@@ -12,7 +18,7 @@ export type SnakeCase<T extends string> = Lowercase<DelimiterCase<T, '_'>>
  * @example snakeCase('hello world') // 'hello_world'
  */
 export function snakeCase<T extends string>(str: T): SnakeCase<T> {
-  return toLowerCase(delimiterCase(str, '_'))
+  return toLowerCase(delimiterCase(removeApostrophe(str), '_'))
 }
 
 /**

--- a/src/utils/word-case/title-case.test.ts
+++ b/src/utils/word-case/title-case.test.ts
@@ -10,6 +10,7 @@ namespace TypeTransforms {
     Equal<
       TitleCase<WeirdTextUnion>,
       | 'Some Weird Cased $* String 1986 Foo Bar W For Wumbo'
+      | 'Wheres The Leak Maam'
       | 'Dont Distribute Unions'
     >
   >

--- a/src/utils/words.test.ts
+++ b/src/utils/words.test.ts
@@ -23,6 +23,9 @@ namespace WordsTests {
   type test2 = Expect<Equal<Words<string>, string[]>>
   type test3 = Expect<Equal<Words<'abc def', string>, string[]>>
   type test4 = Expect<Equal<Words<'abc def', ' ', string>, string[]>>
+  type test5 = Expect<
+    Equal<Words<"Where's the leak ma'am">, ['Wheres', 'the', 'leak', 'maam']>
+  >
 }
 
 type Mutable<Type> = {
@@ -67,6 +70,13 @@ describe('words', () => {
   test('it splits words at casing', () => {
     const expected = ['some', 'Weird', 'Cased', 'STRING', 'Foo'] as const
     const result = words('someWeirdCasedSTRINGFoo')
+    expect(result).toEqual(expected)
+    type test = Expect<Equal<typeof result, Mutable<typeof expected>>>
+  })
+
+  test('it drops apostrophes', () => {
+    const expected = ['Wheres', 'the', 'leak', 'maam'] as const
+    const result = words("Where's the leak ma'am")
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, Mutable<typeof expected>>>
   })

--- a/src/utils/words.test.ts
+++ b/src/utils/words.test.ts
@@ -24,7 +24,7 @@ namespace WordsTests {
   type test3 = Expect<Equal<Words<'abc def', string>, string[]>>
   type test4 = Expect<Equal<Words<'abc def', ' ', string>, string[]>>
   type test5 = Expect<
-    Equal<Words<"Where's the leak ma'am">, ['Wheres', 'the', 'leak', 'maam']>
+    Equal<Words<"Where's the leak ma'am">, ["Where's", 'the', 'leak', "ma'am"]>
   >
 }
 
@@ -74,8 +74,8 @@ describe('words', () => {
     type test = Expect<Equal<typeof result, Mutable<typeof expected>>>
   })
 
-  test('it drops apostrophes', () => {
-    const expected = ['Wheres', 'the', 'leak', 'maam'] as const
+  test('it preserves apostrophes', () => {
+    const expected = ["Where's", 'the', 'leak', "ma'am"] as const
     const result = words("Where's the leak ma'am")
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, Mutable<typeof expected>>>

--- a/src/utils/words.ts
+++ b/src/utils/words.ts
@@ -20,10 +20,10 @@ export type Words<
 > = IsStringLiteral<sentence | word | prev> extends true
   ? sentence extends `${infer curr}${infer rest}`
     ? curr extends "'"
-      ? // Step 0: remove apostrophes
+      ? // Step 0: Remove apostrophes (continue current word)
         Words<rest, word, prev>
       : IsSeparator<curr> extends true
-      ? // Step 1: Remove separators
+      ? // Step 1: Remove separators (end current word)
         Reject<[word, ...Words<rest>], ''>
       : prev extends ''
       ? // Start of sentence, start a new word
@@ -63,8 +63,8 @@ export type Words<
  */
 export function words<T extends string>(sentence: T): Words<T> {
   return sentence
-    .replace(/'/g, '') // Step 0: remove apostrophes
-    .replace(SEPARATOR_REGEX, ' ') // Step 1: Remove separators
+    .replace(/'/g, '') // Step 0: Remove apostrophes (continue current word)
+    .replace(SEPARATOR_REGEX, ' ') // Step 1: Remove separators (end current word)
     .replace(/([a-zA-Z])([0-9])/g, '$1 $2') // Step 2: From non-digit to digit
     .replace(/([0-9])([a-zA-Z])/g, '$1 $2') // Step 3: From digit to non-digit
     .replace(/([a-zA-Z0-9_\-./])([^a-zA-Z0-9_\-./])/g, '$1 $2') // Step 4: From non-special to special

--- a/src/utils/words.ts
+++ b/src/utils/words.ts
@@ -19,11 +19,8 @@ export type Words<
   prev extends string = '',
 > = IsStringLiteral<sentence | word | prev> extends true
   ? sentence extends `${infer curr}${infer rest}`
-    ? curr extends "'"
-      ? // Step 0: Remove apostrophes (continue current word)
-        Words<rest, word, prev>
-      : IsSeparator<curr> extends true
-      ? // Step 1: Remove separators (end current word)
+    ? IsSeparator<curr> extends true
+      ? // Step 1: Remove separators
         Reject<[word, ...Words<rest>], ''>
       : prev extends ''
       ? // Start of sentence, start a new word
@@ -63,12 +60,11 @@ export type Words<
  */
 export function words<T extends string>(sentence: T): Words<T> {
   return sentence
-    .replace(/'/g, '') // Step 0: Remove apostrophes (continue current word)
-    .replace(SEPARATOR_REGEX, ' ') // Step 1: Remove separators (end current word)
+    .replace(SEPARATOR_REGEX, ' ') // Step 1: Remove separators
     .replace(/([a-zA-Z])([0-9])/g, '$1 $2') // Step 2: From non-digit to digit
     .replace(/([0-9])([a-zA-Z])/g, '$1 $2') // Step 3: From digit to non-digit
-    .replace(/([a-zA-Z0-9_\-./])([^a-zA-Z0-9_\-./])/g, '$1 $2') // Step 4: From non-special to special
-    .replace(/([^a-zA-Z0-9_\-./])([a-zA-Z0-9_\-./])/g, '$1 $2') // Step 5: From special to non-special
+    .replace(/([a-zA-Z0-9_\-./])([^a-zA-Z0-9_\-./'])/g, '$1 $2') // Step 4: From non-special to special
+    .replace(/([^a-zA-Z0-9_\-./'])([a-zA-Z0-9_\-./])/g, '$1 $2') // Step 5: From special to non-special
     .replace(/([a-z])([A-Z])/g, '$1 $2') // Step 6: From lower to upper
     .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2') // Step 7: From upper to upper and lower
     .trim() // Step 8: Trim the last word

--- a/src/utils/words.ts
+++ b/src/utils/words.ts
@@ -6,6 +6,7 @@ import type { IsDigit } from './characters/numbers.js'
 import type { IsSpecial } from './characters/special.js'
 import type { IsStringLiteral } from '../internal/literals.js'
 
+// prettier-ignore
 /**
  * Splits a string into words.
  * sentence: The current string to split.
@@ -18,7 +19,10 @@ export type Words<
   prev extends string = '',
 > = IsStringLiteral<sentence | word | prev> extends true
   ? sentence extends `${infer curr}${infer rest}`
-    ? IsSeparator<curr> extends true
+    ? curr extends "'"
+      ? // Step 0: remove apostrophes
+        Words<rest, word, prev>
+      : IsSeparator<curr> extends true
       ? // Step 1: Remove separators
         Reject<[word, ...Words<rest>], ''>
       : prev extends ''
@@ -52,13 +56,14 @@ export type Words<
   : string[] // Avoid spending resources on a wide type
 
 /**
- * A strongly typed function to extract the words from a sentence.
+ * A strongly-typed function to extract the words from a sentence.
  * @param sentence the sentence to extract the words from.
  * @returns an array of words in both type level and runtime.
  * @example words('helloWorld') // ['hello', 'World']
  */
 export function words<T extends string>(sentence: T): Words<T> {
   return sentence
+    .replace(/'/g, '') // Step 0: remove apostrophes
     .replace(SEPARATOR_REGEX, ' ') // Step 1: Remove separators
     .replace(/([a-zA-Z])([0-9])/g, '$1 $2') // Step 2: From non-digit to digit
     .replace(/([0-9])([a-zA-Z])/g, '$1 $2') // Step 3: From digit to non-digit


### PR DESCRIPTION
# Words and Apostophes

`Words` and related casing utilities have weird behavior for words containing `'`.
I updated the logic to be more like lodash's (removing apostrophes before splitting words)

Relates to, but is not a fix for: https://github.com/gustavoguichard/string-ts/issues/122

## Words

```ts
// Old behavior
type test = Expect<Equal<Words<"don'tGo">, ["don", "'", "t", "Go"]>>;
// Updated behavior
type test = Expect<Equal<Words<"don'tGo">, ["dont", "Go"]>>;
```

## Casing

```ts
// Old behavior
type test = Expect<Equal<SnakeCase<"don'tGo">, "don_'_t_go">>;
// Updated behavior
type test = Expect<Equal<SnakeCase<"don'tGo">, "dont_go">>;
```