### PR TITLE
chore: Better test types error messages

### DIFF
--- a/src/internal/types.d.ts
+++ b/src/internal/types.d.ts
@@ -4,4 +4,4 @@ type Equal<A, B> =
   // prettier-ignore
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
     ? true
-    : false
+    : [A, 'should equal', B]


### PR DESCRIPTION
To improve type tests I changed the `Equal` type (as done by @diogob in domain-functions) thus we'll have much better error messages when expectation fails:

## From
<img width="1034" alt="Screenshot 2023-12-19 at 09 12 24" src="https://github.com/gustavoguichard/string-ts/assets/566971/67fb18ba-e4ac-4a6d-988b-64d678323507">

## To
<img width="1090" alt="Screenshot 2023-12-19 at 09 12 07" src="https://github.com/gustavoguichard/string-ts/assets/566971/0c3691c8-ff6c-47dd-b9d6-ab017528f042">
