### PR TITLE
fix: handle template literals in startsWith

### DIFF
--- a/src/native/ends-with.test.ts
+++ b/src/native/ends-with.test.ts
@@ -5,6 +5,15 @@ namespace TypeTests {
   type test2 = Expect<Equal<EndsWith<string, 'c'>, boolean>>
   type test3 = Expect<Equal<EndsWith<Uppercase<string>, 'c'>, boolean>>
   type test4 = Expect<Equal<EndsWith<'abc', string>, boolean>>
+  type test6 = Expect<Equal<EndsWith<'abcde', 'd', 4>, true>>
+  type test7 = Expect<Equal<EndsWith<'abcde', 'e', 4>, false>>
+  type test8 = Expect<Equal<EndsWith<'abcde', 'e', 6>, true>>
+  type test9 = Expect<Equal<EndsWith<'abcde', 'e', -1>, false>>
+
+  // TODO: fix these
+  // // Template strings
+  // type testTS1 = Expect<Equal<EndsWith<`${string}cba`, 'a'>, true>>
+  // type testTS2 = Expect<Equal<StartsWith<`${string}abc`, 'a'>, false>>
 }
 
 describe('endsWith', () => {

--- a/src/native/ends-with.test.ts
+++ b/src/native/ends-with.test.ts
@@ -10,10 +10,13 @@ namespace TypeTests {
   type test8 = Expect<Equal<EndsWith<'abcde', 'e', 6>, true>>
   type test9 = Expect<Equal<EndsWith<'abcde', 'e', -1>, false>>
 
-  // TODO: fix these
   // // Template strings
-  // type testTS1 = Expect<Equal<EndsWith<`${string}cba`, 'a'>, true>>
-  // type testTS2 = Expect<Equal<StartsWith<`${string}abc`, 'a'>, false>>
+  type testTS1 = Expect<Equal<EndsWith<`${string}cba`, 'a'>, true>>
+  type testTS2 = Expect<Equal<EndsWith<`${string}abc`, 'a'>, false>>
+  type testTS3 = Expect<Equal<EndsWith<`zyx${string}cba`, 'a'>, true>>
+  type testTS4 = Expect<Equal<EndsWith<`xyz${string}abc`, 'a'>, false>>
+  type testTS5 = Expect<Equal<EndsWith<`abc${string}xyz`, 'c', 3>, true>>
+  type testTS6 = Expect<Equal<EndsWith<`abc${string}xyz`, 'c', 4>, boolean>>
 }
 
 describe('endsWith', () => {

--- a/src/native/ends-with.test.ts
+++ b/src/native/ends-with.test.ts
@@ -10,7 +10,7 @@ namespace TypeTests {
   type test8 = Expect<Equal<EndsWith<'abcde', 'e', 6>, true>>
   type test9 = Expect<Equal<EndsWith<'abcde', 'e', -1>, false>>
 
-  // // Template strings
+  // Template strings
   type testTS1 = Expect<Equal<EndsWith<`${string}cba`, 'a'>, true>>
   type testTS2 = Expect<Equal<EndsWith<`${string}abc`, 'a'>, false>>
   type testTS3 = Expect<Equal<EndsWith<`zyx${string}cba`, 'a'>, true>>

--- a/src/native/ends-with.ts
+++ b/src/native/ends-with.ts
@@ -1,6 +1,8 @@
 import type { Math } from '../internal/math.js'
 import type { Length } from './length.js'
 import type { Slice } from './slice.js'
+import type { StartsWith } from './starts-with.js'
+import type { Reverse } from '../utils/reverse.js'
 import type {
   All,
   IsNumberLiteral,
@@ -16,16 +18,28 @@ import type {
 export type EndsWith<
   T extends string,
   S extends string,
-  P extends number = Length<T>,
-> = All<[IsStringLiteral<T | S>, IsNumberLiteral<P>]> extends true
+  P extends number | undefined = undefined,
+> = P extends number ? _EndsWith<T, S, P> : _EndsWithNoPosition<T, S>
+
+type _EndsWith<T extends string, S extends string, P extends number> = All<
+  [IsStringLiteral<S>, IsNumberLiteral<P>]
+> extends true
   ? Math.IsNegative<P> extends false
     ? P extends Length<T>
-      ? S extends Slice<T, Math.Subtract<Length<T>, Length<S>>, Length<T>>
-        ? true
-        : false
-      : EndsWith<Slice<T, 0, P>, S, Length<T>> // P !== T.length, slice
+      ? IsStringLiteral<T> extends true
+        ? S extends Slice<T, Math.Subtract<Length<T>, Length<S>>, Length<T>>
+          ? true
+          : false
+        : _EndsWithNoPosition<Slice<T, 0, P>, S> // Eg: EndsWith<`abc${string}xyz`, 'c', 3>
+      : _EndsWithNoPosition<Slice<T, 0, P>, S> // P !== T.length, slice
     : false // P is negative, false
   : boolean
+
+/** Overload of EndsWith without P */
+type _EndsWithNoPosition<T extends string, S extends string> = StartsWith<
+  Reverse<T>,
+  Reverse<S>
+>
 
 /**
  * A strongly-typed version of `String.prototype.endsWith`.

--- a/src/native/slice.test.ts
+++ b/src/native/slice.test.ts
@@ -8,12 +8,15 @@ namespace TypeTests {
   type test5 = Expect<Equal<Slice<'some nice string', number, 9>, string>>
   type test6 = Expect<Equal<Slice<'some nice string', 5, number>, string>>
   type test7 = Expect<Equal<Slice<'abcde', -3>, 'cde'>>
+  type test8 = Expect<Equal<Slice<'abc', 10>, ''>>
+  type test9 = Expect<Equal<Slice<'abc', 10, 12>, ''>>
 
   // Template literals
   type testTS1 = Expect<Equal<Slice<`abc${string}`, 1, 3>, 'bc'>>
   type testTS2 = Expect<Equal<Slice<`abcd${string}`, 1, 3>, 'bc'>>
-  type testTS3 = Expect<Equal<Slice<`${string}abcd`, 1, 3>, string>>
-  type testTS4 = Expect<Equal<Slice<`abc${string}`, 1>, `bc${string}`>>
+  type testTS3 = Expect<Equal<Slice<`abc${string}xyz`, 0, 3>, 'abc'>>
+  type testTS4 = Expect<Equal<Slice<`${string}abcd`, 1, 3>, string>>
+  type testTS5 = Expect<Equal<Slice<`abc${string}`, 1>, `bc${string}`>>
 }
 
 describe('slice', () => {

--- a/src/native/slice.test.ts
+++ b/src/native/slice.test.ts
@@ -7,12 +7,13 @@ namespace TypeTests {
   type test4 = Expect<Equal<Slice<Uppercase<string>, 5, 9>, string>>
   type test5 = Expect<Equal<Slice<'some nice string', number, 9>, string>>
   type test6 = Expect<Equal<Slice<'some nice string', 5, number>, string>>
-  type test7 = Expect<Equal<Slice<`abc${string}`, 1, 3>, 'bc'>>
-  type test8 = Expect<Equal<Slice<`abcd${string}`, 1, 3>, 'bc'>>
-  type test9 = Expect<Equal<Slice<`${string}abcd`, 1, 3>, string>>
+  type test7 = Expect<Equal<Slice<'abcde', -3>, 'cde'>>
 
-  // TODO: Won't work because endIndex defaults to Length<`abc${string}`> which is `number`
-  // type test_ = Expect<Equal<Slice<`abc${string}`, 1>, `bc${string}`>>
+  // Template literals
+  type testTS1 = Expect<Equal<Slice<`abc${string}`, 1, 3>, 'bc'>>
+  type testTS2 = Expect<Equal<Slice<`abcd${string}`, 1, 3>, 'bc'>>
+  type testTS3 = Expect<Equal<Slice<`${string}abcd`, 1, 3>, string>>
+  type testTS4 = Expect<Equal<Slice<`abc${string}`, 1>, `bc${string}`>>
 }
 
 describe('slice', () => {

--- a/src/native/slice.test.ts
+++ b/src/native/slice.test.ts
@@ -7,6 +7,12 @@ namespace TypeTests {
   type test4 = Expect<Equal<Slice<Uppercase<string>, 5, 9>, string>>
   type test5 = Expect<Equal<Slice<'some nice string', number, 9>, string>>
   type test6 = Expect<Equal<Slice<'some nice string', 5, number>, string>>
+  type test7 = Expect<Equal<Slice<`abc${string}`, 1, 3>, 'bc'>>
+  type test8 = Expect<Equal<Slice<`abcd${string}`, 1, 3>, 'bc'>>
+  type test9 = Expect<Equal<Slice<`${string}abcd`, 1, 3>, string>>
+
+  // TODO: Won't work because endIndex defaults to Length<`abc${string}`> which is `number`
+  // type test_ = Expect<Equal<Slice<`abc${string}`, 1>, `bc${string}`>>
 }
 
 describe('slice', () => {

--- a/src/native/slice.ts
+++ b/src/native/slice.ts
@@ -39,13 +39,13 @@ type _Slice<
             Math.Subtract<Math.GetPositiveIndex<T, endIndex>, 1>,
             _result
           >
-      : string // Head is non-literal
+      : startIndex | endIndex extends 0
+        ? _result
+        : string // Head is non-literal
     : IsStringLiteral<T> extends true // Couldn't be split into head/tail
       ? _result // T ran out
-      : startIndex extends 0
-        ? endIndex extends 0
-          ? _result // Eg: Slice<`abc${string}`, 1, 3> -> 'bc'
-          : string // Head is non-literal
+      : startIndex | endIndex extends 0
+        ? _result // Eg: Slice<`abc${string}`, 1, 3> -> 'bc'
         : string // Head is non-literal
   : string
 

--- a/src/native/slice.ts
+++ b/src/native/slice.ts
@@ -1,10 +1,6 @@
 import type { Math } from '../internal/math.js'
 import type { Length } from './length.js'
-import type {
-  All,
-  IsStringLiteral,
-  IsNumberLiteral,
-} from '../internal/literals.js'
+import type { IsStringLiteral, IsNumberLiteral } from '../internal/literals.js'
 
 /**
  * Slices a string from a startIndex to an endIndex.
@@ -16,25 +12,35 @@ export type Slice<
   T extends string,
   startIndex extends number = 0,
   endIndex extends number = Length<T>,
-> = All<
-  [IsStringLiteral<T>, IsNumberLiteral<startIndex | endIndex>]
-> extends true
+  _result extends string = '',
+> = IsNumberLiteral<startIndex | endIndex> extends true
   ? T extends `${infer head}${infer rest}`
-    ? startIndex extends 0
-      ? endIndex extends 0
-        ? ''
-        : `${head}${Slice<
+    ? IsStringLiteral<head> extends true
+      ? startIndex extends 0
+        ? endIndex extends 0
+          ? _result
+          : Slice<
+              rest,
+              0,
+              Math.Subtract<Math.GetPositiveIndex<T, endIndex>, 1>,
+              `${_result}${head}`
+            >
+        : Slice<
             rest,
             Math.Subtract<Math.GetPositiveIndex<T, startIndex>, 1>,
-            Math.Subtract<Math.GetPositiveIndex<T, endIndex>, 1>
-          >}`
-      : `${Slice<
-          rest,
-          Math.Subtract<Math.GetPositiveIndex<T, startIndex>, 1>,
-          Math.Subtract<Math.GetPositiveIndex<T, endIndex>, 1>
-        >}`
-    : ''
+            Math.Subtract<Math.GetPositiveIndex<T, endIndex>, 1>,
+            _result
+          >
+      : string // Head is non-literal
+    : IsStringLiteral<T> extends true // Couldn't be split into head/tail
+      ? _result // T ran out
+      : startIndex extends 0
+        ? endIndex extends 0
+          ? _result // Eg: Slice<`abc${string}`, 1, 3> -> 'bc'
+          : string // Head is non-literal
+        : string // Head is non-literal
   : string
+
 /**
  * A strongly-typed version of `String.prototype.slice`.
  * @param str the string to slice.

--- a/src/native/starts-with.test.ts
+++ b/src/native/starts-with.test.ts
@@ -7,8 +7,10 @@ namespace TypeTests {
   type test4 = Expect<Equal<StartsWith<string, 'a'>, boolean>>
   type test5 = Expect<Equal<StartsWith<'abc', string>, boolean>>
   type test6 = Expect<Equal<StartsWith<'abc', 'a', number>, boolean>>
-  type test7 = Expect<Equal<StartsWith<`abc-${string}`, 'a'>, true>>
+  type test7 = Expect<Equal<StartsWith<`abc${string}`, 'a'>, true>>
   type test8 = Expect<Equal<StartsWith<`cba${string}`, 'a'>, false>>
+  // TODO: fix
+  type test9 = Expect<Equal<StartsWith<`abc${string}`, 'abc'>, true>>
 }
 
 describe('startsWith', () => {

--- a/src/native/starts-with.test.ts
+++ b/src/native/starts-with.test.ts
@@ -7,6 +7,8 @@ namespace TypeTests {
   type test4 = Expect<Equal<StartsWith<string, 'a'>, boolean>>
   type test5 = Expect<Equal<StartsWith<'abc', string>, boolean>>
   type test6 = Expect<Equal<StartsWith<'abc', 'a', number>, boolean>>
+  type test7 = Expect<Equal<StartsWith<`abc-${string}`, 'a'>, true>>
+  type test8 = Expect<Equal<StartsWith<`cba${string}`, 'a'>, false>>
 }
 
 describe('startsWith', () => {

--- a/src/native/starts-with.test.ts
+++ b/src/native/starts-with.test.ts
@@ -10,6 +10,9 @@ namespace TypeTests {
   type test7 = Expect<Equal<StartsWith<`abc${string}`, 'a'>, true>>
   type test8 = Expect<Equal<StartsWith<`cba${string}`, 'a'>, false>>
   type test9 = Expect<Equal<StartsWith<`abc${string}`, 'abc'>, true>>
+
+  // TODO: won't work while Slice endIndex defaults to Length<`abc${string}`> which is `number`
+  // type test_ = Expect<Equal<StartsWith<`abc${string}`, 'b', 1>, true>>
 }
 
 describe('startsWith', () => {

--- a/src/native/starts-with.test.ts
+++ b/src/native/starts-with.test.ts
@@ -9,7 +9,6 @@ namespace TypeTests {
   type test6 = Expect<Equal<StartsWith<'abc', 'a', number>, boolean>>
   type test7 = Expect<Equal<StartsWith<`abc${string}`, 'a'>, true>>
   type test8 = Expect<Equal<StartsWith<`cba${string}`, 'a'>, false>>
-  // TODO: fix
   type test9 = Expect<Equal<StartsWith<`abc${string}`, 'abc'>, true>>
 }
 

--- a/src/native/starts-with.test.ts
+++ b/src/native/starts-with.test.ts
@@ -10,9 +10,7 @@ namespace TypeTests {
   type test7 = Expect<Equal<StartsWith<`abc${string}`, 'a'>, true>>
   type test8 = Expect<Equal<StartsWith<`cba${string}`, 'a'>, false>>
   type test9 = Expect<Equal<StartsWith<`abc${string}`, 'abc'>, true>>
-
-  // TODO: won't work while Slice endIndex defaults to Length<`abc${string}`> which is `number`
-  // type test_ = Expect<Equal<StartsWith<`abc${string}`, 'b', 1>, true>>
+  type test10 = Expect<Equal<StartsWith<`abc${string}`, 'b', 1>, true>>
 }
 
 describe('startsWith', () => {

--- a/src/native/starts-with.ts
+++ b/src/native/starts-with.ts
@@ -19,17 +19,17 @@ export type StartsWith<
 > = All<[IsStringLiteral<S>, IsNumberLiteral<P>]> extends true
   ? Math.IsNegative<P> extends false
     ? P extends 0
-      ? T extends `${infer THead}${infer TRest}`
-        ? S extends `${infer SHead}${infer SRest}`
+      ? S extends `${infer SHead}${infer SRest}`
+        ? T extends `${infer THead}${infer TRest}`
           ? IsStringLiteral<THead | SHead> extends true
             ? THead extends SHead
               ? StartsWith<TRest, SRest>
               : false // Heads weren't equal
             : boolean // THead is non-literal
-          : true // Couldn't split S, we've already ruled out non-literal
-        : IsStringLiteral<T> extends true // Couldn't split T
-          ? false // T ran out, but we still have S
-          : boolean // T (or TRest) is not a literal
+          : IsStringLiteral<T> extends true // Couldn't split T
+            ? false // T ran out, but we still have S
+            : boolean // T (or TRest) is not a literal
+        : true // Couldn't split S, we've already ruled out non-literal
       : StartsWith<Slice<T, P>, S, 0> // P is >0, slice
     : StartsWith<T, S, 0> // P is negative, ignore it
   : boolean

--- a/src/native/starts-with.ts
+++ b/src/native/starts-with.ts
@@ -16,12 +16,20 @@ export type StartsWith<
   T extends string,
   S extends string,
   P extends number = 0,
-> = All<[IsStringLiteral<T | S>, IsNumberLiteral<P>]> extends true
+> = All<[IsStringLiteral<S>, IsNumberLiteral<P>]> extends true
   ? Math.IsNegative<P> extends false
     ? P extends 0
-      ? T extends `${S}${string}`
-        ? true
-        : false
+      ? T extends `${infer THead}${infer TRest}`
+        ? S extends `${infer SHead}${infer SRest}`
+          ? IsStringLiteral<THead | SHead> extends true
+            ? Equal<THead, SHead> extends true
+              ? StartsWith<TRest, SRest>
+              : false // Heads weren't equal
+            : false // Both heads are literals
+          : true // Couldn't split S, we've already ruled out non-literal
+        : IsStringLiteral<T> extends true // Couldn't split T
+          ? false // T ran out, but we still have S
+          : boolean // T (or TRest) is not a literal
       : StartsWith<Slice<T, P>, S, 0> // P is >0, slice
     : StartsWith<T, S, 0> // P is negative, ignore it
   : boolean

--- a/src/native/starts-with.ts
+++ b/src/native/starts-with.ts
@@ -22,10 +22,10 @@ export type StartsWith<
       ? T extends `${infer THead}${infer TRest}`
         ? S extends `${infer SHead}${infer SRest}`
           ? IsStringLiteral<THead | SHead> extends true
-            ? Equal<THead, SHead> extends true
+            ? THead extends SHead
               ? StartsWith<TRest, SRest>
               : false // Heads weren't equal
-            : false // Both heads are literals
+            : boolean // THead is non-literal
           : true // Couldn't split S, we've already ruled out non-literal
         : IsStringLiteral<T> extends true // Couldn't split T
           ? false // T ran out, but we still have S

--- a/src/utils/reverse.test.ts
+++ b/src/utils/reverse.test.ts
@@ -8,6 +8,11 @@ namespace ReverseTests {
   >
   type test4 = Expect<Equal<Reverse<string>, string>>
   type test5 = Expect<Equal<Reverse<Uppercase<string>>, Uppercase<string>>>
+
+  // Template strings
+  type testTS1 = Expect<Equal<Reverse<`abc${string}`>, `${string}cba`>>
+  type testTS2 = Expect<Equal<Reverse<`abc${string}xyz`>, `zyx${string}cba`>>
+  type testTS3 = Expect<Equal<Reverse<`${string}xyz`>, `zyx${string}`>>
 }
 
 describe('reverse', () => {
@@ -20,8 +25,10 @@ describe('reverse', () => {
   })
 
   test('should reverse a long string', () => {
-    const expected = 'murobal tse di mina tillom tnuresed aiciffo iuq apluc ni tnus ,tnediorp non tatadipuc taceacco tnis ruetpecxE .rutairap allun taiguf ue erolod mullic esse tilev etatpulov ni tiredneherper ni rolod eruri etua siuD .tauqesnoc odommoc ae xe piuqila tu isin sirobal ocmallu noitaticrexe durtson siuq ,mainev minim da mine tU .auqila angam erolod te erobal tu tnudidicni ropmet domsuie od des ,tile gnicsipida rutetcesnoc ,tema tis rolod muspi meroL'
-    const data = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+    const expected =
+      'murobal tse di mina tillom tnuresed aiciffo iuq apluc ni tnus ,tnediorp non tatadipuc taceacco tnis ruetpecxE .rutairap allun taiguf ue erolod mullic esse tilev etatpulov ni tiredneherper ni rolod eruri etua siuD .tauqesnoc odommoc ae xe piuqila tu isin sirobal ocmallu noitaticrexe durtson siuq ,mainev minim da mine tU .auqila angam erolod te erobal tu tnudidicni ropmet domsuie od des ,tile gnicsipida rutetcesnoc ,tema tis rolod muspi meroL'
+    const data =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
     const result = reverse(data)
     expect(result).toEqual(expected)
     type test = Expect<Equal<typeof result, typeof expected>>

--- a/src/utils/reverse.ts
+++ b/src/utils/reverse.ts
@@ -2,9 +2,14 @@
  * Reverses a string.
  * - `T` The string to reverse.
  */
-type Reverse<T extends string, _acc extends string = ''> = T extends `${infer Head}${infer Tail}`
+type Reverse<
+  T extends string,
+  _acc extends string = '',
+> = T extends `${infer Head}${infer Tail}`
   ? Reverse<Tail, `${Head}${_acc}`>
-  : _acc extends '' ? T : _acc
+  : _acc extends ''
+    ? T
+    : `${T}${_acc}`
 
 /**
  * A strongly-typed function to reverse a string.


### PR DESCRIPTION
Relates to: https://github.com/gustavoguichard/string-ts/issues/181

## Description

I needed to have more granular control over the comparison, so I replaced the 
`${S}${string}` 
part with 
`${infer THead}${infer TRest}`

I needed to remove `Length<T>` in a lot of places -- it doesn't work with template literals.

## Details

`Length` does not (and cannot) handle string interpolation well.
```ts
Length<'abc'> // 3
Length<`abc${string}`> // number
```
`Slice<T, startIndex, endIndex>` uses `Length<T>` as the default value for `endIndex`. 
Both `StartsWith`/`EndsWith` use `Slice`.

I refactored `Slice`/`StartsWith`/`EndsWith` to not use `Length` (or only use it when `T` is known to be a literal) and I now have them working with template literals.

Also, `slice`/`startsWith`/`endsWith` are not methods with default number arguments (eg: `0` or `Length<T>`), they are overloads where the last arguments are optionally provided.

Consider
```ts
slice(start?: number | undefined, end?: number | undefined): string
startsWith(searchString: string, position?: number | undefined): boolean
endsWith(searchString: string, endPosition?: number | undefined): boolean
```

In other words, updating the params for these types to be
`P: number | undefined = undefined`
instead of
`P: number = Length<T>`
makes this fix possible _and_ more closely aligns our types with the TS definitions for those string methods.
