### PR TITLE
fix: Expose deepTransformKeys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,3 +105,5 @@ export type { DeepPascalKeys } from './utils/object-keys/deep-pascal-keys.js'
 export { deepPascalKeys } from './utils/object-keys/deep-pascal-keys.js'
 export type { DeepSnakeKeys } from './utils/object-keys/deep-snake-keys.js'
 export { deepSnakeKeys } from './utils/object-keys/deep-snake-keys.js'
+
+export { deepTransformKeys } from './utils/object-keys/deep-transform-keys.js'


### PR DESCRIPTION
It is already in the README and should thus be exposed