### PR TITLE
Export character union types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
-      "native": ["dist/native.d.ts"]
+      "native": [
+        "dist/native.d.ts"
+      ]
     }
   },
   "devDependencies": {
@@ -41,7 +43,10 @@
     "typescript": "^5.7.3",
     "vitest": "latest"
   },
-  "files": ["README.md", "./dist/*"],
+  "files": [
+    "README.md",
+    "./dist/*"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gustavoguichard/string-ts.git"
@@ -51,6 +56,10 @@
   },
   "sideEffects": false,
   "pnpm": {
-    "onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
-  }
+    "onlyBuiltDependencies": [
+      "@biomejs/biome",
+      "esbuild"
+    ]
+  },
+  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,10 @@ export type { Words } from './utils/words.js'
 export { words } from './utils/words.js'
 
 // Characters
-export type { IsLetter, IsLower, IsUpper } from './utils/characters/letters.js'
-export type { IsDigit } from './utils/characters/numbers.js'
+export type { IsLetter, IsLower, IsUpper, LowerLetter, LowerLetters, UpperLetter, UpperLetters, Letter, Letters } from './utils/characters/letters.js'
+export type { IsDigit, Digit, Digits } from './utils/characters/numbers.js'
 export type { IsSpecial } from './utils/characters/special.js'
-export type { IsSeparator } from './utils/characters/separators.js'
+export type { IsSeparator, Separator, Separators } from './utils/characters/separators.js'
 
 // Word casing
 export type { CamelCase } from './utils/word-case/camel-case.js'

--- a/src/utils/characters/letters.ts
+++ b/src/utils/characters/letters.ts
@@ -1,40 +1,73 @@
 import type { IsStringLiteral } from '../../internal/literals.js'
 
-type UpperChars =
-  | 'A'
-  | 'B'
-  | 'C'
-  | 'D'
-  | 'E'
-  | 'F'
-  | 'G'
-  | 'H'
-  | 'I'
-  | 'J'
-  | 'K'
-  | 'L'
-  | 'M'
-  | 'N'
-  | 'O'
-  | 'P'
-  | 'Q'
-  | 'R'
-  | 'S'
-  | 'T'
-  | 'U'
-  | 'V'
-  | 'W'
-  | 'X'
-  | 'Y'
-  | 'Z'
-type LowerChars = Lowercase<UpperChars>
+export type UpperLetters = [
+    'A'
+  , 'B'
+  , 'C'
+  , 'D'
+  , 'E'
+  , 'F'
+  , 'G'
+  , 'H'
+  , 'I'
+  , 'J'
+  , 'K'
+  , 'L'
+  , 'M'
+  , 'N'
+  , 'O'
+  , 'P'
+  , 'Q'
+  , 'R'
+  , 'S'
+  , 'T'
+  , 'U'
+  , 'V'
+  , 'W'
+  , 'X'
+  , 'Y'
+  , 'Z'
+]
+export type UpperLetter = UpperLetters[number]
+export type LowerLetters = [
+    'a'
+  , 'b'
+  , 'c'
+  , 'd'
+  , 'e'
+  , 'f'
+  , 'g'
+  , 'h'
+  , 'i'
+  , 'j'
+  , 'k'
+  , 'l'
+  , 'm'
+  , 'n'
+  , 'o'
+  , 'p'
+  , 'q'
+  , 'r'
+  , 's'
+  , 't'
+  , 'u'
+  , 'v'
+  , 'w'
+  , 'x'
+  , 'y'
+  , 'z'
+]
+export type LowerLetter = LowerLetters[number]
+
+export type Letters = [...LowerLetters, ...UpperLetters]
+export type Letter = LowerLetter | UpperLetter
 
 // UTILITIES FOR DETECTING CHARS
 /**
  * Checks if the given character is an upper case letter.
  */
 export type IsUpper<T extends string> = IsStringLiteral<T> extends true
-  ? T extends UpperChars
+  ? T extends UpperLetter
     ? true
     : false
   : boolean
@@ -43,7 +76,7 @@ export type IsUpper<T extends string> = IsStringLiteral<T> extends true
  * Checks if the given character is a lower case letter.
  */
 export type IsLower<T extends string> = IsStringLiteral<T> extends true
-  ? T extends LowerChars
+  ? T extends LowerLetter
     ? true
     : false
   : boolean
@@ -52,7 +85,7 @@ export type IsLower<T extends string> = IsStringLiteral<T> extends true
  * Checks if the given character is a letter.
  */
 export type IsLetter<T extends string> = IsStringLiteral<T> extends true
-  ? T extends LowerChars | UpperChars
+  ? T extends Letter
     ? true
     : false
   : boolean

--- a/src/utils/characters/numbers.ts
+++ b/src/utils/characters/numbers.ts
@@ -1,6 +1,7 @@
 import type { IsStringLiteral } from '../../internal/literals.js'
 
-export type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+export type Digits = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+export type Digit = Digits[number];
 
 /**
  * Checks if the given character is a number.

--- a/src/utils/characters/separators.ts
+++ b/src/utils/characters/separators.ts
@@ -26,7 +26,8 @@ export const SEPARATOR_REGEX = new RegExp(
   'g'
 )
 
-export type Separator = (typeof SEPARATORS)[number]
+export type Separators = typeof SEPARATORS
+export type Separator = Separators[number]
 
 /**
  * Checks if the given character is a separator.


### PR DESCRIPTION
Exports the character union types.

Having these types is essential, IMO. It's a simple change and goes a long way on DX as DRYness.