### PR TITLE
fix: cap Repeat type at 45 to prevent TS2589 depth error

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ We have tested it with build tools like Webpack, Vite, Rollup, etc.
 
 `string-ts` currently only works on TypeScript v5+.
 
-It also only work with common ASCII characters characters. We don't plan to support international characters or emojis.
+See also: [Known limitations](#known-limitations).
 
 ## 🪄 Native String Method Overrides
 
@@ -319,6 +319,8 @@ const result = padStart(str, 10, '=')
 ### repeat
 
 This function is a strongly-typed counterpart of `String.prototype.repeat`.
+
+_Note: for counts above 45 the return type falls back to `string` to avoid TypeScript's type-instantiation depth limit. See [Known limitations](#known-limitations)._
 
 ```ts
 import { repeat } from 'string-ts'
@@ -971,6 +973,24 @@ type MyType<T> = { [K in keyof T as Uppercase<K>]: T[K] }
 const result = deepTransformKeys(data, toUpperCase) as MyType<typeof data>
 //    ^ { 'HELLOWORLD': 'baz' }
 ```
+
+## Known limitations
+
+### ASCII only
+
+`string-ts` only works with common ASCII characters. We don't plan to support international characters or emojis.
+
+### Type-level recursion depth
+
+TypeScript has an internal limit on how deeply it can evaluate recursive types. Some `string-ts` types rely on recursion, so very large inputs will cause the type to fall back to `string` (or a template literal like `` `${string}hello` ``) instead of computing the exact literal.
+
+| Function / Type | Exact-literal limit | Behaviour beyond limit |
+|---|---|---|
+| `repeat` / `Repeat` | count ≤ 45 | Returns `string` |
+| `padStart` / `PadStart` | padding ≤ 45 chars | Returns `` `${string}<original>` `` |
+| `padEnd` / `PadEnd` | padding ≤ 45 chars | Returns `` `<original>${string}` `` |
+
+Runtime behaviour is unaffected — only the inferred type widens.
 
 ## 🎙️ Interview
 

--- a/src/native/pad-end.ts
+++ b/src/native/pad-end.ts
@@ -32,6 +32,9 @@ export type PadEnd<
  * @param length the length to pad.
  * @param pad the string to pad with.
  * @returns the padded string in both type level and runtime.
+ * When the required padding exceeds 45 characters the return type
+ * becomes a template literal (e.g. `` `hello${string}` ``) instead of
+ * an exact literal.
  * @example padEnd('hello', 10, '=') // 'hello====='
  */
 export function padEnd<

--- a/src/native/pad-start.ts
+++ b/src/native/pad-start.ts
@@ -31,6 +31,9 @@ export type PadStart<
  * @param length the length to pad.
  * @param pad the string to pad with.
  * @returns the padded string in both type level and runtime.
+ * When the required padding exceeds 45 characters the return type
+ * becomes a template literal (e.g. `` `${string}hello` ``) instead of
+ * an exact literal.
  * @example padStart('hello', 10, '=') // '=====hello'
  */
 export function padStart<

--- a/src/native/repeat.test.ts
+++ b/src/native/repeat.test.ts
@@ -6,6 +6,13 @@ namespace TypeTests {
   type test3 = Expect<Equal<Repeat<Uppercase<string>, 3>, string>>
   type test4 = Expect<Equal<Repeat<' ', number>, string>>
   type test5 = Expect<Equal<Repeat<'a' | 'b', 2>, 'aa' | 'bb'>>
+  type test6 = Expect<Equal<Repeat<'═', 80>, string>>
+  type test7 = Expect<Equal<Repeat<'a', 100>, string>>
+  type test8 = Expect<Equal<Repeat<'a', 10>, 'aaaaaaaaaa'>>
+  type test9 = Expect<
+    Equal<Repeat<'a', 45>, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'>
+  >
+  type test10 = Expect<Equal<Repeat<'a', 46>, string>>
 }
 
 describe('repeat', () => {
@@ -34,5 +41,11 @@ describe('repeat', () => {
     const result = repeat(data, 2)
     expect(['aa', 'bb']).toContain(result)
     type test = Expect<Equal<typeof result, 'aa' | 'bb'>>
+  })
+
+  test('should fall back to string type for large repeat counts', () => {
+    const result = repeat('═', 80)
+    expect(result).toEqual('═'.repeat(80))
+    type test = Expect<Equal<typeof result, string>>
   })
 })

--- a/src/native/repeat.ts
+++ b/src/native/repeat.ts
@@ -7,17 +7,70 @@ import type {
 import type { Math } from '../internal/math.js'
 import type { Join } from './join.js'
 
+type SafeRepeatCount =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23
+  | 24
+  | 25
+  | 26
+  | 27
+  | 28
+  | 29
+  | 30
+  | 31
+  | 32
+  | 33
+  | 34
+  | 35
+  | 36
+  | 37
+  | 38
+  | 39
+  | 40
+  | 41
+  | 42
+  | 43
+  | 44
+  | 45
+
 /**
  * Repeats a string N times.
  * T: The string to repeat.
  * N: The number of times to repeat.
+ *
+ * For counts above 45 the return type falls back to `string` to avoid
+ * hitting TypeScript's type-instantiation depth limit.
  */
 export type Repeat<T extends string, times extends number = 0> = T extends T
   ? All<[IsStringLiteral<T>, IsNumberLiteral<times>]> extends true
     ? times extends 0
       ? ''
       : Math.IsNegative<times> extends false
-        ? Join<TupleOf<times, T>>
+        ? times extends SafeRepeatCount
+          ? Join<TupleOf<times, T>>
+          : string
         : never
     : string
   : never
@@ -27,6 +80,7 @@ export type Repeat<T extends string, times extends number = 0> = T extends T
  * @param str the string to repeat.
  * @param times the number of times to repeat.
  * @returns the repeated string in both type level and runtime.
+ * For counts above 45 the return type falls back to `string`.
  * @example repeat('hello', 3) // 'hellohellohello'
  */
 export function repeat<T extends string, N extends number = 0>(


### PR DESCRIPTION
## Summary

- Adds a `SafeRepeatCount` union (0–45) that gates the exact-literal branch of the `Repeat` type. Counts above 45 gracefully fall back to `string` instead of triggering TS2589
- `padStart` / `padEnd` inherit this fix since they use `Repeat` internally — large padding falls back to a template literal (e.g. `` `${string}hello` ``) rather than erroring
- Adds a **Known limitations** section to the README covering ASCII-only support and the recursion-depth threshold
- Updates JSDoc on `repeat`, `padStart`, and `padEnd` to document the 45-count limit

Fixes #292

## Test plan

- [x] `npm test` — 160 tests pass
- [x] `npm run tsc` — zero type errors
- [x] `npm run lint` — clean
- [x] Verified `Repeat<'a', 45>` resolves to exact literal
- [x] Verified `Repeat<'a', 46>` and `Repeat<'═', 80>` resolve to `string` (no TS2589)
- [x] Verified `PadStart<'hello', 80, '='>` resolves to `` `${string}hello` `` (no TS2589)
- [x] Verified `Slice`, `EndsWith`, `Truncate` unaffected with large inputs (200+)